### PR TITLE
Translations and more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(vermouth VERSION 1.3.2 LANGUAGES CXX)
+project(vermouth VERSION 1.3.3 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -89,6 +89,8 @@ target_compile_definitions(vermouth PRIVATE
     APP_COPYRIGHT="${APP_COPYRIGHT}"
     APP_ID="${APP_ID}"
 )
+
+ki18n_install(po)
 
 install(TARGETS vermouth ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
 install(FILES assets/${APP_ID}.desktop DESTINATION ${KDE_INSTALL_APPDIR})

--- a/README.md
+++ b/README.md
@@ -204,6 +204,32 @@ To create desktop shortcuts for your games, add `xdg-desktop` to filesystem perm
 
 Games are stored in `~/.config/vermouth/apps.json`. When umu-launcher is available, Proton is launched through it with `PROTONPATH` and `STEAM_COMPAT_DATA_PATH` set. Without umu, Vermouth calls the `proton run` script directly, the same way Steam does. Wine games get `WINEPREFIX` set and the binary called directly.
 
+## Contributing
+
+Contributions are welcome. Please open a pull request on [GitHub](https://github.com/dekomote/vermouth).
+
+### Code
+
+Build from source (see [Building from source](#building-from-source)), make your changes, and open a pull request. Keep changes focused - one feature or fix per PR.
+
+### Translations
+
+Vermouth uses the KDE i18n system (gettext `.po` files). To add or update a translation:
+
+1. Create a folder `po/<language_code>/` (e.g. `po/fr/` for French, `po/pt_BR/` for Brazilian Portuguese).
+2. Copy `po/vermouth.pot` into it as `vermouth.po` (e.g. `po/fr/vermouth.po`).
+3. Fill in the `msgstr` fields with your translations.
+4. Open a pull request with your new folder.
+
+To update an existing translation after new strings have been added:
+
+```bash
+sh po/Messages.sh       # regenerate vermouth.pot from source
+sh po/update-po.sh      # merge new strings into all .po files
+```
+
+Then fill in any new empty `msgstr ""` entries in your `.po` file.
+
 ## AI Disclaimer
 
 The code has been developed, reviewed and tested by a human. However, development included assistance of AI tools, so keep that in mind.

--- a/com.dekomote.vermouth.flathub.yml
+++ b/com.dekomote.vermouth.flathub.yml
@@ -20,4 +20,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/dekomote/vermouth.git
-        tag: v1.3.2
+        tag: v1.3.3

--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vermouth
 	pkgdesc = A no-frills Wine/Proton game launcher for Linux
-	pkgver = 1.3.2
+	pkgver = 1.3.3
 	pkgrel = 1
 	url = https://github.com/dekomote/vermouth
 	arch = x86_64
@@ -15,7 +15,7 @@ pkgbase = vermouth
 	depends = kcoreaddons
 	depends = qqc2-desktop-style
 	optdepends = icoutils: Windows icon extraction
-	source = vermouth-1.3.2.tar.gz::https://github.com/dekomote/vermouth/archive/refs/tags/v1.3.2.tar.gz
+	source = vermouth-1.3.3.tar.gz::https://github.com/dekomote/vermouth/archive/refs/tags/v1.3.3.tar.gz
 	sha256sums = c69c0884225867130d3f09fbcb55bf8cbb578f9a9b9fecb4993890aab9d366b5
 
 pkgname = vermouth

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Dejan Noveski <deko@duck.com>
 pkgname=vermouth
-pkgver=1.3.2
+pkgver=1.3.3
 pkgrel=1
 pkgdesc="A no-frills Wine/Proton game launcher for Linux"
 arch=('x86_64')

--- a/packaging/vermouth.spec
+++ b/packaging/vermouth.spec
@@ -1,5 +1,5 @@
 Name:           vermouth
-Version:        1.3.2
+Version:        1.3.3
 Release:        1%{?dist}
 Summary:        A no-frills Wine/Proton game launcher for KDE
 License:        MIT
@@ -69,6 +69,8 @@ lets you run Windows executables through Proton or Wine on KDE.
 %{_datadir}/metainfo/com.dekomote.vermouth.metainfo.xml
 
 %changelog
+* Mon Apr 20 2026 Dejan Noveski <deko@duck.com> - 1.3.3-1
+- Single prefix support, known exe launch, Stop button, HDR disable, translations
 * Fri Apr 17 2026 Dejan Noveski <deko@duck.com> - 1.3.2-1
 - UMU prefix fixed, added single instance support
 * Fri Apr 17 2026 Dejan Noveski <deko@duck.com> - 1.3.1-1

--- a/po/messages.sh
+++ b/po/messages.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Extracts translatable strings from C++ and QML sources into vermouth.pot
+
+BASEDIR=$(dirname "$0")/..
+POTFILE="$BASEDIR/po/vermouth.pot"
+
+find "$BASEDIR/src" -name "*.cpp" -o -name "*.h" | sort | \
+xgettext --files-from=- \
+    --language=C++ \
+    --keyword=i18n \
+    --keyword=i18nc:1c,2 \
+    --keyword=i18np:1,2 \
+    --keyword=i18ncp:1c,2,3 \
+    --from-code=UTF-8 \
+    --output="$POTFILE" \
+    --package-name=vermouth \
+
+find "$BASEDIR/qml" -name "*.qml" | sort | \
+xgettext --files-from=- \
+    --language=JavaScript \
+    --keyword=i18n \
+    --keyword=i18nc:1c,2 \
+    --keyword=i18np:1,2 \
+    --keyword=i18ncp:1c,2,3 \
+    --from-code=UTF-8 \
+    --join-existing \
+    --output="$POTFILE" \
+    --package-name=vermouth \
+
+echo "Updated $POTFILE"

--- a/po/mk/vermouth.po
+++ b/po/mk/vermouth.po
@@ -1,0 +1,550 @@
+# Vermouth in Macedonian.
+# Copyright (C) 2026 DEJAN NOVESKI
+# This file is distributed under the same license as the PACKAGE package.
+# DEJAN NOVESKI <DEKO@DUCK.COM>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: 1.3.3\n"
+"Report-Msgid-Bugs-To: deko@duck.com\n"
+"POT-Creation-Date: 2026-04-20 12:28+0200\n"
+"PO-Revision-Date: 2026-04-20 11:37+0200\n"
+"Last-Translator: DEJAN NOVESKI <DEKO@DUCK.COM>\n"
+"Language-Team: Macedonian\n"
+"Language: mk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
+
+#: po/../src/main.cpp:27
+msgid "Vermouth"
+msgstr "Vermouth"
+
+#: po/../src/main.cpp:32
+msgid "Lead Developer"
+msgstr "Главен програмер"
+
+#: po/../src/main.cpp:47
+msgid "Launch app by its config ID"
+msgstr "Стартувaj апликација по нејзиниот конфигурациски ID"
+
+#: po/../src/main.cpp:48
+msgid "Launch exe with Proton"
+msgstr "Стартувaj exe со Proton"
+
+#: po/../src/main.cpp:49
+msgid "Launch exe with Wine"
+msgstr "Стартуваj exe со Wine"
+
+#: po/../src/main.cpp:50
+msgid "Proton path"
+msgstr "Патека до Proton"
+
+#: po/../src/main.cpp:51
+msgid "Wine binary path"
+msgstr "Патека до Wine бинарна датотека"
+
+#: po/../src/main.cpp:52
+msgid "Prefix path"
+msgstr "Патека до префикс"
+
+#: po/../src/main.cpp:53
+#, c-format
+msgid "Launch options (use %command% as placeholder)"
+msgstr "Опции за стартување (користете %command% како замена)"
+
+#: po/../src/main.cpp:54
+msgid "Enable logging to file"
+msgstr "Овозможи запишување во датотека"
+
+#: po/../src/main.cpp:64
+msgid "File or URI to open"
+msgstr "Датотека или URI за отворање"
+
+#: po/../qml/AddAppDialog.qml:9
+msgid "Edit App/Game"
+msgstr "Уреди апликација/игра"
+
+#: po/../qml/AddAppDialog.qml:9
+msgid "Add App/Game"
+msgstr "Додади апликација/игра"
+
+#: po/../qml/AddAppDialog.qml:17
+msgid "OK"
+msgstr "Во ред"
+
+#: po/../qml/AddAppDialog.qml:27 po/../qml/RunExeStandaloneDialog.qml:27
+msgid "Cancel"
+msgstr "Откажи"
+
+#: po/../qml/AddAppDialog.qml:97
+msgid "Name is required."
+msgstr "Името е задолжително."
+
+#: po/../qml/AddAppDialog.qml:101 po/../qml/RunExeStandaloneDialog.qml:44
+msgid "Executable path is required."
+msgstr "Патеката до извршната датотека е задолжителна."
+
+#: po/../qml/AddAppDialog.qml:140
+msgid "Game"
+msgstr "Игра"
+
+#: po/../qml/AddAppDialog.qml:146
+msgid "Name:"
+msgstr "Име:"
+
+#: po/../qml/AddAppDialog.qml:147
+msgid "My Game"
+msgstr "Моја игра"
+
+#: po/../qml/AddAppDialog.qml:151 po/../qml/RunExeDialog.qml:37
+#: po/../qml/RunExeStandaloneDialog.qml:92
+msgid "Executable (.exe):"
+msgstr "Извршна датотека (.exe):"
+
+#: po/../qml/AddAppDialog.qml:164
+msgid "Icon (optional):"
+msgstr "Икона (незадолжително):"
+
+#: po/../qml/AddAppDialog.qml:188
+msgid "Proton Prefix (optional):"
+msgstr "Протон Префикс (незадолжително):"
+
+#: po/../qml/AddAppDialog.qml:202
+msgid "Wine Prefix (WINEPREFIX):"
+msgstr "Wine Префикс (WINEPREFIX):"
+
+#: po/../qml/AddAppDialog.qml:216 po/../qml/RunExeStandaloneDialog.qml:116
+msgid "Options"
+msgstr "Опции"
+
+#: po/../qml/AddAppDialog.qml:221 po/../qml/RunExeStandaloneDialog.qml:121
+msgid "Launch Options (optional):"
+msgstr "Опции за стартување (незадолжително):"
+
+#: po/../qml/AddAppDialog.qml:222
+msgid "e.g. mangohud %command%"
+msgstr "пр. mangohud %command%"
+
+#: po/../qml/AddAppDialog.qml:227
+msgid "Write output to log file"
+msgstr "Запиши излез во датотека за дневник"
+
+#: po/../qml/AddAppDialog.qml:233
+msgid "Global Env Vars:"
+msgstr "Глобални env променливи:"
+
+#: po/../qml/AddAppDialog.qml:244 po/../qml/RunExeDialog.qml:53
+#: po/../qml/RunExeStandaloneDialog.qml:129
+msgid "Select Executable"
+msgstr "Изберете извршна датотека"
+
+#: po/../qml/AddAppDialog.qml:246 po/../qml/RunExeDialog.qml:55
+#: po/../qml/RunExeStandaloneDialog.qml:131
+msgid "Executables (*.exe)"
+msgstr "Извршни датотеки (*.exe)"
+
+#: po/../qml/AddAppDialog.qml:246 po/../qml/AddAppDialog.qml:257
+#: po/../qml/RunExeDialog.qml:55 po/../qml/RunExeStandaloneDialog.qml:131
+msgid "All files (*)"
+msgstr "Сите датотеки (*)"
+
+#: po/../qml/AddAppDialog.qml:255
+msgid "Select Icon"
+msgstr "Изберете икона"
+
+#: po/../qml/AddAppDialog.qml:257
+msgid "Images (*.png *.svg *.ico *.jpg)"
+msgstr "Слики (*.png *.svg *.ico *.jpg)"
+
+#: po/../qml/AddAppDialog.qml:263
+msgid "Select Proton Prefix Folder"
+msgstr "Изберете папка за Proton Префикс"
+
+#: po/../qml/AddAppDialog.qml:270
+msgid "Select Wine Prefix Folder"
+msgstr "Изберете папка за Wine Префикс"
+
+#: po/../qml/AppGridView.qml:226
+msgid "Stop"
+msgstr "Запри"
+
+#: po/../qml/AppGridView.qml:226
+msgid "Launch"
+msgstr "Стартувај"
+
+#: po/../qml/AppGridView.qml:240
+msgid "Launch with logging"
+msgstr "Стартувај со запишување"
+
+#: po/../qml/AppGridView.qml:253
+msgid "Run another EXE in this prefix"
+msgstr "Стартувај друг EXE во овој префикс"
+
+#: po/../qml/AppGridView.qml:262
+msgid "Create start menu entry"
+msgstr "Создај ставка во стартното мени"
+
+#: po/../qml/AppGridView.qml:270
+msgid "Create desktop shortcut"
+msgstr "Создај кратенка на работната површина"
+
+#: po/../qml/AppGridView.qml:278
+msgid "&Wine Utilities"
+msgstr "&Wine алатки"
+
+#: po/../qml/AppGridView.qml:282
+msgid "Run Winecfg"
+msgstr "Стартувај Winecfg"
+
+#: po/../qml/AppGridView.qml:290
+msgid "Run Regedit"
+msgstr "Стартувај Regedit"
+
+#: po/../qml/AppGridView.qml:298
+msgid "Run Winetricks"
+msgstr "Стартувај Winetricks"
+
+#: po/../qml/AppGridView.qml:312
+msgid "Open log folder"
+msgstr "Отвори папка за дневник"
+
+#: po/../qml/AppGridView.qml:317
+msgid "Open prefix folder"
+msgstr "Отвори папка за prefix"
+
+#: po/../qml/AppGridView.qml:328
+msgid "Edit"
+msgstr "Уреди"
+
+#: po/../qml/AppGridView.qml:333
+msgid "Remove"
+msgstr "Отстрани"
+
+#: po/../qml/AppGridView.qml:341
+msgid "Remove and Delete Prefix"
+msgstr "Отстрани и избриши префикс"
+
+#: po/../qml/AppGridView.qml:354
+msgid "Delete both app and prefix?"
+msgstr "Да се избришат и апликацијата и prefix-от?"
+
+#: po/../qml/AppGridView.qml:355
+msgid "This will delete both the app and the prefix?"
+msgstr "Ова ќе ги избрише и апликацијата и префиксот."
+
+#: po/../qml/AppGridView.qml:363
+msgid "Delete the app?"
+msgstr "Да се избрише апликацијата?"
+
+#: po/../qml/AppGridView.qml:364
+msgid "This will delete the app but preserve the prefix folder."
+msgstr "Ова ќе ја избрише апликацијата, но ќе ја зачува папката со префиксот."
+
+#: po/../qml/AppGridView.qml:371
+msgid "Winetricks not found"
+msgstr "Winetricks не е пронајден"
+
+#: po/../qml/AppGridView.qml:372
+msgid ""
+"Winetricks is not installed on your system. Please install it using your "
+"package manager."
+msgstr ""
+"Winetricks не е инсталиран на вашиот систем. Инсталирајте го преку вашиот "
+"менаџер на пакети."
+
+#: po/../qml/AppGridView.qml:380
+msgid "No apps or games added yet"
+msgstr "Сè уште нема додадено апликации или игри"
+
+#: po/../qml/AppGridView.qml:381
+msgid "Click \"Add App/Game\" to get started"
+msgstr "Кликнете „Додади апликација/игра“ за да започнете"
+
+#: po/../qml/Main.qml:28
+msgid "Unpin sidebar"
+msgstr "Откачи странична лента"
+
+#: po/../qml/Main.qml:28
+msgid "Pin sidebar"
+msgstr "Закачи странична лента"
+
+#: po/../qml/Main.qml:36 po/../qml/Main.qml:90
+msgid "Add &App/Game"
+msgstr "Додади &апликација/игра"
+
+#: po/../qml/Main.qml:41
+msgid "Run &Standalone EXE"
+msgstr "Стартување на &самостоен EXE"
+
+#: po/../qml/Main.qml:46 po/../qml/Main.qml:132
+msgid "Allow Sleep"
+msgstr "Дозволи спиење"
+
+#: po/../qml/Main.qml:46 po/../qml/Main.qml:132
+msgid "Prevent Sleep"
+msgstr "Спречи спиење"
+
+#: po/../qml/Main.qml:53 po/../qml/Main.qml:142
+msgid "Disable HDR"
+msgstr "Оневозможи HDR"
+
+#: po/../qml/Main.qml:53 po/../qml/Main.qml:142
+msgid "Enable HDR"
+msgstr "Овозможи HDR"
+
+#: po/../qml/Main.qml:61
+msgid "&Settings"
+msgstr "&Поставки"
+
+#: po/../qml/Main.qml:66
+msgid "&About Vermouth"
+msgstr "&За Vermouth"
+
+#: po/../qml/Main.qml:71
+msgid "Quit"
+msgstr "Излез"
+
+#: po/../qml/Main.qml:122
+msgid "%1 - %2"
+msgstr "%1 — %2"
+
+#: po/../qml/Main.qml:185
+msgid "Open Executable"
+msgstr "Отвори извршна датотека"
+
+#: po/../qml/Main.qml:190
+msgid "Run Standalone"
+msgstr "Стартување самостојно"
+
+#: po/../qml/Main.qml:198
+msgid "Add to Library"
+msgstr "Додади во библиотека"
+
+#: po/../qml/Main.qml:215
+msgid "Prefix not ready"
+msgstr "Prefix не е подготвен"
+
+#: po/../qml/Main.qml:216
+msgid ""
+"The prefix for \"%1\" has not been created yet. Please launch the game at "
+"least once first."
+msgstr ""
+"Префикс за \"%1\" сè уште не е создаден. Ве молиме стартувајте ја играта "
+"барем еднаш прво."
+
+#: po/../qml/Main.qml:270
+msgid "Launched: %1"
+msgstr "Стартувано: %1"
+
+#: po/../qml/Main.qml:273
+msgid "Error: %1"
+msgstr "Грешка: %1"
+
+#: po/../qml/RunExeDialog.qml:9
+msgid "Run EXE in Prefix"
+msgstr "Стартување на EXE во префикс"
+
+#: po/../qml/RunExeDialog.qml:29
+msgid "Run an executable using the same prefix as \"%1\""
+msgstr "Стартување на извршна датотека со истиот префикс како \"%1\""
+
+#: po/../qml/RunExeStandaloneDialog.qml:9
+msgid "Run Standalone EXE"
+msgstr "Стартување на самостоен EXE"
+
+#: po/../qml/RunExeStandaloneDialog.qml:17
+msgid "Run"
+msgstr "Стартувај"
+
+#: po/../qml/RunExeStandaloneDialog.qml:122
+msgid "e.g ENV_VAR1=2"
+msgstr "пр. ENV_VAR1=2"
+
+#: po/../qml/RuntimePicker.qml:14
+msgid "Runtime"
+msgstr "Извршно опкружување"
+
+#: po/../qml/RuntimePicker.qml:64
+msgid "Please select a Proton version."
+msgstr "Изберете верзија на Proton."
+
+#: po/../qml/RuntimePicker.qml:67
+msgid "Wine binary path is required."
+msgstr "Патеката до Wine бинарна датотека е задолжителна."
+
+#: po/../qml/RuntimePicker.qml:106
+msgid "Runtime:"
+msgstr "Извршно опкружување:"
+
+#: po/../qml/RuntimePicker.qml:112
+msgid "Proton Version:"
+msgstr "Верзија на Proton:"
+
+#: po/../qml/RuntimePicker.qml:118 po/../qml/RuntimePicker.qml:120
+msgid ""
+"No Proton versions found. Download GE Proton to get started - no Steam or "
+"manual setup needed."
+msgstr ""
+"Не се пронајдени верзии на Proton. Преземете GE Proton за да започнете - не "
+"е потребен Steam или рачно поставување."
+
+#: po/../qml/RuntimePicker.qml:125
+msgid "Open Vermouth Proton folder (%1)"
+msgstr "Отвори папка за Vermouth Proton (%1)"
+
+#: po/../qml/RuntimePicker.qml:131
+msgid "Refresh Proton versions"
+msgstr "Освежи листа на верзии на Proton"
+
+#: po/../qml/RuntimePicker.qml:138 po/../qml/SettingsDialog.qml:184
+msgid "Download latest GE Proton"
+msgstr "Преземи ја најновата GE Proton"
+
+#: po/../qml/RuntimePicker.qml:145
+msgid "Wine Binary:"
+msgstr "Wine бинарна датотека:"
+
+#: po/../qml/RuntimePicker.qml:160
+msgid "Select Wine Binary"
+msgstr "Изберете Wine бинарна датотека"
+
+#: po/../qml/SettingsDialog.qml:9
+msgid "Settings"
+msgstr "Поставки"
+
+#: po/../qml/SettingsDialog.qml:66
+msgid "Default Runtime"
+msgstr "Стандардно извршно опкружување"
+
+#: po/../qml/SettingsDialog.qml:74
+msgid "umu-launcher"
+msgstr "umu-launcher"
+
+#: po/../qml/SettingsDialog.qml:79
+msgid ""
+"umu-launcher runs Proton through the Steam Runtime (pressure-vessel), which "
+"significantly improves game compatibility - especially for games with video "
+"cutscenes or anti-cheat. Strongly recommended."
+msgstr ""
+"umu-launcher го извршува Proton преку Steam Runtime (pressure-vessel), што "
+"значително ја подобрува компатибилноста на игрите — особено за игри со видео-"
+"сцени или анти-чит. Силно препорачано."
+
+#: po/../qml/SettingsDialog.qml:88
+msgid "umu-run path:"
+msgstr "Патека до umu-run:"
+
+#: po/../qml/SettingsDialog.qml:92
+msgid "Auto-detect (umu-run in PATH)"
+msgstr "Автоматско откривање (umu-run во PATH)"
+
+#: po/../qml/SettingsDialog.qml:102
+msgid "Download latest umu-launcher"
+msgstr "Преземи ја најновата umu-launcher"
+
+#: po/../qml/SettingsDialog.qml:116
+msgid "Prefixes"
+msgstr "Префикси"
+
+#: po/../qml/SettingsDialog.qml:120
+msgid "Default Prefix Parent Folder:"
+msgstr "Стандардна папка за префикси:"
+
+#: po/../qml/SettingsDialog.qml:134
+msgid ""
+"This is the folder where Vermouth stores all the created prefixes by default."
+msgstr ""
+"Ова е папката каде Vermouth ги складира сите создадени префикси стандардно."
+
+#: po/../qml/SettingsDialog.qml:143
+msgid "Default App/Game Prefix:"
+msgstr "Стандарден префикс за апликација/игра:"
+
+#: po/../qml/SettingsDialog.qml:147
+msgid "Auto-generate per app/game"
+msgstr "Автоматско генерирање за секоја апликација/игра"
+
+#: po/../qml/SettingsDialog.qml:157
+msgid ""
+"Set this if you want all apps and games to share a single prefix (e.g. one "
+"Wine/Proton environment for everything). Leave empty to auto-generate a "
+"separate prefix per game. You can still use separate prefixe per game, but "
+"you have to set it explicitly."
+msgstr ""
+"Поставете го ова ако сакате сите апликации и игри да споделуваат еден префикс "
+"(пр. едно Wine/Proton опкружување за сè). Оставете празно за автоматско "
+"генерирање на посебен префикс за секоја игра. Сепак може да користите посебен "
+"префикс по игра, но мора да го поставите рачно."
+
+#: po/../qml/SettingsDialog.qml:167
+msgid "Vermouth Proton Folder"
+msgstr "Папка за Vermouth Proton"
+
+#: po/../qml/SettingsDialog.qml:171
+msgid ""
+"Download GE Proton to run most games and apps - no Steam or manual setup "
+"needed."
+msgstr ""
+"Преземете GE Proton за да стартувате повеќето игри и апликации - не е "
+"потребен Steam или рачно поставување."
+
+#: po/../qml/SettingsDialog.qml:174
+msgid "Open Vermouth Proton folder"
+msgstr "Отвори папка за Vermouth Proton"
+
+#: po/../qml/SettingsDialog.qml:180
+msgid "Download Latest GE Proton"
+msgstr "Преземи ја најновата GE Proton"
+
+#: po/../qml/SettingsDialog.qml:191
+msgid "Extra Proton Scan Paths"
+msgstr "Дополнителни патеки за скенирање на Proton"
+
+#: po/../qml/SettingsDialog.qml:195
+msgid ""
+"Folders to scan for Proton installations (in addition to Steam and local "
+"paths)."
+msgstr ""
+"Папки за скенирање на Proton инсталации (покрај Steam и локалните патеки)."
+
+#: po/../qml/SettingsDialog.qml:217
+msgid "Add Path..."
+msgstr "Додади патека..."
+
+#: po/../qml/SettingsDialog.qml:225
+msgid "Global Environment Variables"
+msgstr "Глобални променливи на опкружувањето"
+
+#: po/../qml/SettingsDialog.qml:229
+msgid "Applied to every game. Per-game launch options can override these."
+msgstr "Се применуваат на секоја игра. Опциите за секоја игра можат да ги заменат."
+
+#: po/../qml/SettingsDialog.qml:237
+msgid "KEY"
+msgstr "КЛУЧ"
+
+#: po/../qml/SettingsDialog.qml:246
+msgid "value"
+msgstr "вредност"
+
+#: po/../qml/SettingsDialog.qml:259
+msgid "Add Variable"
+msgstr "Додади променлива"
+
+#: po/../qml/SettingsDialog.qml:272
+msgid "Select umu-run binary"
+msgstr "Изберете umu-run бинарна датотека"
+
+#: po/../qml/SettingsDialog.qml:279
+msgid "Select Default Prefix Folder"
+msgstr "Изберете стандардна папка за prefix"
+
+#: po/../qml/SettingsDialog.qml:286
+msgid "Select Default App/Game Prefix"
+msgstr "Изберете стандарден prefix за апликација/игра"
+
+#: po/../qml/SettingsDialog.qml:293
+msgid "Select Proton Scan Folder"
+msgstr "Изберете папка за скенирање на Proton"

--- a/po/update-po.sh
+++ b/po/update-po.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Merges updated vermouth.pot into all language .po files
+
+BASEDIR=$(dirname "$0")
+POTFILE="$BASEDIR/vermouth.pot"
+
+for po in "$BASEDIR"/*/vermouth.po; do
+    echo "Updating $po..."
+    msgmerge --update --backup=none "$po" "$POTFILE"
+done
+
+echo "Done."

--- a/po/vermouth.pot
+++ b/po/vermouth.pot
@@ -1,0 +1,533 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the vermouth package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: vermouth\n"
+"Report-Msgid-Bugs-To: deko@duck.com\n"
+"POT-Creation-Date: 2026-04-20 12:28+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: po/../src/main.cpp:27
+msgid "Vermouth"
+msgstr ""
+
+#: po/../src/main.cpp:32
+msgid "Lead Developer"
+msgstr ""
+
+#: po/../src/main.cpp:47
+msgid "Launch app by its config ID"
+msgstr ""
+
+#: po/../src/main.cpp:48
+msgid "Launch exe with Proton"
+msgstr ""
+
+#: po/../src/main.cpp:49
+msgid "Launch exe with Wine"
+msgstr ""
+
+#: po/../src/main.cpp:50
+msgid "Proton path"
+msgstr ""
+
+#: po/../src/main.cpp:51
+msgid "Wine binary path"
+msgstr ""
+
+#: po/../src/main.cpp:52
+msgid "Prefix path"
+msgstr ""
+
+#: po/../src/main.cpp:53
+#, c-format
+msgid "Launch options (use %command% as placeholder)"
+msgstr ""
+
+#: po/../src/main.cpp:54
+msgid "Enable logging to file"
+msgstr ""
+
+#: po/../src/main.cpp:64
+msgid "File or URI to open"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:9
+msgid "Edit App/Game"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:9
+msgid "Add App/Game"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:17
+msgid "OK"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:27 po/../qml/RunExeStandaloneDialog.qml:27
+msgid "Cancel"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:97
+msgid "Name is required."
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:101 po/../qml/RunExeStandaloneDialog.qml:44
+msgid "Executable path is required."
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:140
+msgid "Game"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:146
+msgid "Name:"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:147
+msgid "My Game"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:151 po/../qml/RunExeDialog.qml:37
+#: po/../qml/RunExeStandaloneDialog.qml:92
+msgid "Executable (.exe):"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:164
+msgid "Icon (optional):"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:188
+msgid "Proton Prefix (optional):"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:202
+msgid "Wine Prefix (WINEPREFIX):"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:216 po/../qml/RunExeStandaloneDialog.qml:116
+msgid "Options"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:221 po/../qml/RunExeStandaloneDialog.qml:121
+msgid "Launch Options (optional):"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:222
+msgid "e.g. mangohud %command%"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:227
+msgid "Write output to log file"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:233
+msgid "Global Env Vars:"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:244 po/../qml/RunExeDialog.qml:53
+#: po/../qml/RunExeStandaloneDialog.qml:129
+msgid "Select Executable"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:246 po/../qml/RunExeDialog.qml:55
+#: po/../qml/RunExeStandaloneDialog.qml:131
+msgid "Executables (*.exe)"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:246 po/../qml/AddAppDialog.qml:257
+#: po/../qml/RunExeDialog.qml:55 po/../qml/RunExeStandaloneDialog.qml:131
+msgid "All files (*)"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:255
+msgid "Select Icon"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:257
+msgid "Images (*.png *.svg *.ico *.jpg)"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:263
+msgid "Select Proton Prefix Folder"
+msgstr ""
+
+#: po/../qml/AddAppDialog.qml:270
+msgid "Select Wine Prefix Folder"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:226
+msgid "Stop"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:226
+msgid "Launch"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:240
+msgid "Launch with logging"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:253
+msgid "Run another EXE in this prefix"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:262
+msgid "Create start menu entry"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:270
+msgid "Create desktop shortcut"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:278
+msgid "&Wine Utilities"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:282
+msgid "Run Winecfg"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:290
+msgid "Run Regedit"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:298
+msgid "Run Winetricks"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:312
+msgid "Open log folder"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:317
+msgid "Open prefix folder"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:328
+msgid "Edit"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:333
+msgid "Remove"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:341
+msgid "Remove and Delete Prefix"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:354
+msgid "Delete both app and prefix?"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:355
+msgid "This will delete both the app and the prefix?"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:363
+msgid "Delete the app?"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:364
+msgid "This will delete the app but preserve the prefix folder."
+msgstr ""
+
+#: po/../qml/AppGridView.qml:371
+msgid "Winetricks not found"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:372
+msgid ""
+"Winetricks is not installed on your system. Please install it using your "
+"package manager."
+msgstr ""
+
+#: po/../qml/AppGridView.qml:380
+msgid "No apps or games added yet"
+msgstr ""
+
+#: po/../qml/AppGridView.qml:381
+msgid "Click \"Add App/Game\" to get started"
+msgstr ""
+
+#: po/../qml/Main.qml:28
+msgid "Unpin sidebar"
+msgstr ""
+
+#: po/../qml/Main.qml:28
+msgid "Pin sidebar"
+msgstr ""
+
+#: po/../qml/Main.qml:36 po/../qml/Main.qml:90
+msgid "Add &App/Game"
+msgstr ""
+
+#: po/../qml/Main.qml:41
+msgid "Run &Standalone EXE"
+msgstr ""
+
+#: po/../qml/Main.qml:46 po/../qml/Main.qml:132
+msgid "Allow Sleep"
+msgstr ""
+
+#: po/../qml/Main.qml:46 po/../qml/Main.qml:132
+msgid "Prevent Sleep"
+msgstr ""
+
+#: po/../qml/Main.qml:53 po/../qml/Main.qml:142
+msgid "Disable HDR"
+msgstr ""
+
+#: po/../qml/Main.qml:53 po/../qml/Main.qml:142
+msgid "Enable HDR"
+msgstr ""
+
+#: po/../qml/Main.qml:61
+msgid "&Settings"
+msgstr ""
+
+#: po/../qml/Main.qml:66
+msgid "&About Vermouth"
+msgstr ""
+
+#: po/../qml/Main.qml:71
+msgid "Quit"
+msgstr ""
+
+#: po/../qml/Main.qml:122
+msgid "%1 - %2"
+msgstr ""
+
+#: po/../qml/Main.qml:185
+msgid "Open Executable"
+msgstr ""
+
+#: po/../qml/Main.qml:190
+msgid "Run Standalone"
+msgstr ""
+
+#: po/../qml/Main.qml:198
+msgid "Add to Library"
+msgstr ""
+
+#: po/../qml/Main.qml:215
+msgid "Prefix not ready"
+msgstr ""
+
+#: po/../qml/Main.qml:216
+msgid ""
+"The prefix for \"%1\" has not been created yet. Please launch the game at "
+"least once first."
+msgstr ""
+
+#: po/../qml/Main.qml:270
+msgid "Launched: %1"
+msgstr ""
+
+#: po/../qml/Main.qml:273
+msgid "Error: %1"
+msgstr ""
+
+#: po/../qml/RunExeDialog.qml:9
+msgid "Run EXE in Prefix"
+msgstr ""
+
+#: po/../qml/RunExeDialog.qml:29
+msgid "Run an executable using the same prefix as \"%1\""
+msgstr ""
+
+#: po/../qml/RunExeStandaloneDialog.qml:9
+msgid "Run Standalone EXE"
+msgstr ""
+
+#: po/../qml/RunExeStandaloneDialog.qml:17
+msgid "Run"
+msgstr ""
+
+#: po/../qml/RunExeStandaloneDialog.qml:122
+msgid "e.g ENV_VAR1=2"
+msgstr ""
+
+#: po/../qml/RuntimePicker.qml:14
+msgid "Runtime"
+msgstr ""
+
+#: po/../qml/RuntimePicker.qml:64
+msgid "Please select a Proton version."
+msgstr ""
+
+#: po/../qml/RuntimePicker.qml:67
+msgid "Wine binary path is required."
+msgstr ""
+
+#: po/../qml/RuntimePicker.qml:106
+msgid "Runtime:"
+msgstr ""
+
+#: po/../qml/RuntimePicker.qml:112
+msgid "Proton Version:"
+msgstr ""
+
+#: po/../qml/RuntimePicker.qml:118 po/../qml/RuntimePicker.qml:120
+msgid ""
+"No Proton versions found. Download GE Proton to get started - no Steam or "
+"manual setup needed."
+msgstr ""
+
+#: po/../qml/RuntimePicker.qml:125
+msgid "Open Vermouth Proton folder (%1)"
+msgstr ""
+
+#: po/../qml/RuntimePicker.qml:131
+msgid "Refresh Proton versions"
+msgstr ""
+
+#: po/../qml/RuntimePicker.qml:138 po/../qml/SettingsDialog.qml:184
+msgid "Download latest GE Proton"
+msgstr ""
+
+#: po/../qml/RuntimePicker.qml:145
+msgid "Wine Binary:"
+msgstr ""
+
+#: po/../qml/RuntimePicker.qml:160
+msgid "Select Wine Binary"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:9
+msgid "Settings"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:66
+msgid "Default Runtime"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:74
+msgid "umu-launcher"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:79
+msgid ""
+"umu-launcher runs Proton through the Steam Runtime (pressure-vessel), which "
+"significantly improves game compatibility - especially for games with video "
+"cutscenes or anti-cheat. Strongly recommended."
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:88
+msgid "umu-run path:"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:92
+msgid "Auto-detect (umu-run in PATH)"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:102
+msgid "Download latest umu-launcher"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:116
+msgid "Prefixes"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:120
+msgid "Default Prefix Parent Folder:"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:134
+msgid ""
+"This is the folder where Vermouth stores all the created prefixes by default."
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:143
+msgid "Default App/Game Prefix:"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:147
+msgid "Auto-generate per app/game"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:157
+msgid ""
+"Set this if you want all apps and games to share a single prefix (e.g. one "
+"Wine/Proton environment for everything). Leave empty to auto-generate a "
+"separate prefix per game. You can still use separate prefixe per game, but "
+"you have to set it explicitly."
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:167
+msgid "Vermouth Proton Folder"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:171
+msgid ""
+"Download GE Proton to run most games and apps - no Steam or manual setup "
+"needed."
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:174
+msgid "Open Vermouth Proton folder"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:180
+msgid "Download Latest GE Proton"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:191
+msgid "Extra Proton Scan Paths"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:195
+msgid ""
+"Folders to scan for Proton installations (in addition to Steam and local "
+"paths)."
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:217
+msgid "Add Path..."
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:225
+msgid "Global Environment Variables"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:229
+msgid "Applied to every game. Per-game launch options can override these."
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:237
+msgid "KEY"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:246
+msgid "value"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:259
+msgid "Add Variable"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:272
+msgid "Select umu-run binary"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:279
+msgid "Select Default Prefix Folder"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:286
+msgid "Select Default App/Game Prefix"
+msgstr ""
+
+#: po/../qml/SettingsDialog.qml:293
+msgid "Select Proton Scan Folder"
+msgstr ""

--- a/qml/AddAppDialog.qml
+++ b/qml/AddAppDialog.qml
@@ -61,12 +61,12 @@ Kirigami.Dialog {
             var filename = parts[parts.length - 1];
             nameField.text = filename.replace(/\.exe$/i, "");
         }
-        var safeName = nameField.text.replace(/[^a-zA-Z0-9_-]/g, "_").toLowerCase();
-        var prefixBase = dialog.prefixBasePath + "/" + safeName;
+        var defaultPrefix = settingsManager.defaultGamePrefix;
+        var resolvedPrefix = defaultPrefix !== "" ? defaultPrefix : dialog.prefixBasePath + "/" + nameField.text.replace(/[^a-zA-Z0-9_-]/g, "_").toLowerCase();
         if (protonPrefixField.text === "")
-            protonPrefixField.text = prefixBase;
+            protonPrefixField.text = resolvedPrefix;
         if (winePrefixField.text === "")
-            winePrefixField.text = prefixBase;
+            winePrefixField.text = resolvedPrefix;
     }
 
     function openForNewWithExe(exePath) {
@@ -189,7 +189,7 @@ Kirigami.Dialog {
                 QQC2.TextField {
                     id: protonPrefixField
                     Layout.fillWidth: true
-                    placeholderText: dialog.prefixBasePath + "/mygame"
+                    placeholderText: settingsManager.defaultGamePrefix !== "" ? settingsManager.defaultGamePrefix : dialog.prefixBasePath + "/mygame"
                 }
                 QQC2.Button {
                     icon.name: "document-open"
@@ -203,7 +203,7 @@ Kirigami.Dialog {
                 QQC2.TextField {
                     id: winePrefixField
                     Layout.fillWidth: true
-                    placeholderText: "~/.wine"
+                    placeholderText: settingsManager.defaultGamePrefix !== "" ? settingsManager.defaultGamePrefix : "~/.wine"
                 }
                 QQC2.Button {
                     icon.name: "document-open"
@@ -225,6 +225,16 @@ Kirigami.Dialog {
             QQC2.CheckBox {
                 id: enableLoggingCheck
                 text: i18n("Write output to log file")
+            }
+
+            Repeater {
+                model: settingsManager.globalEnvVars
+                delegate: QQC2.Label {
+                    Kirigami.FormData.label: index === 0 ? i18n("Global Env Vars:") : ""
+                    text: modelData
+                    font.family: "monospace"
+                    opacity: 0.7
+                }
             }
         }
     }
@@ -251,14 +261,14 @@ Kirigami.Dialog {
     FolderDialog {
         id: prefixFolderDialog
         title: i18n("Select Proton Prefix Folder")
-        currentFolder: "file://" + protonScanner.homePath()
+        currentFolder: "file://" + dialog.prefixBasePath
         onAccepted: protonPrefixField.text = decodeURIComponent(selectedFolder.toString().replace("file://", ""))
     }
 
     FolderDialog {
         id: winePrefixFolderDialog
         title: i18n("Select Wine Prefix Folder")
-        currentFolder: "file://" + protonScanner.homePath()
+        currentFolder: "file://" + dialog.prefixBasePath
         onAccepted: winePrefixField.text = decodeURIComponent(selectedFolder.toString().replace("file://", ""))
     }
 }

--- a/qml/AppGridView.qml
+++ b/qml/AppGridView.qml
@@ -222,13 +222,18 @@ GridView {
         QQC2.Menu {
             id: contextMenu
             QQC2.MenuItem {
-                text: i18n("Launch")
-                icon.name: "media-playback-start"
+                property bool isRunning: launcher.runningExePaths.indexOf(delegateRoot.exePath) >= 0
+                text: isRunning ? i18n("Stop") : i18n("Launch")
+                icon.name: isRunning ? "media-playback-stop" : "media-playback-start"
                 onTriggered: {
-                    launchAnim.start();
-                    flashAnim.start();
                     var app = appModel.getApp(delegateRoot.index);
-                    launcher.launchEntry(app);
+                    if (isRunning) {
+                        launcher.stopEntry(app);
+                    } else {
+                        launchAnim.start();
+                        flashAnim.start();
+                        launcher.launchEntry(app);
+                    }
                 }
             }
             QQC2.MenuItem {

--- a/qml/AppGridView.qml
+++ b/qml/AppGridView.qml
@@ -15,7 +15,7 @@ GridView {
         property alias scaleFactor: gridView.scaleFactor
     }
     cellWidth: 140 * scaleFactor
-    cellHeight: 170 * scaleFactor
+    cellHeight: 160 * scaleFactor
     clip: true
     focus: true
     keyNavigationEnabled: true
@@ -152,12 +152,12 @@ GridView {
                     Layout.preferredWidth: 80 * gridView.scaleFactor
                     Layout.preferredHeight: 80 * gridView.scaleFactor
                     radius: Kirigami.Units.cornerRadius
-                    color: Kirigami.Theme.alternateBackgroundColor
+                    color: delegateRoot.iconPath === "" ? Kirigami.Theme.alternateBackgroundColor : Kirigami.Theme.backgroundColor
 
                     Image {
                         anchors.centerIn: parent
-                        width: 64 * gridView.scaleFactor
-                        height: 64 * gridView.scaleFactor
+                        width: 70 * gridView.scaleFactor
+                        height: 70 * gridView.scaleFactor
                         source: delegateRoot.iconPath !== "" ? "file://" + delegateRoot.iconPath : ""
                         visible: delegateRoot.iconPath !== ""
                         fillMode: Image.PreserveAspectFit
@@ -182,26 +182,9 @@ GridView {
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                     Layout.fillWidth: true
-                    Layout.maximumHeight: 50 * gridView.scaleFactor
+                    Layout.fillHeight: true
                     wrapMode: Text.Wrap
                     maximumLineCount: 2
-                }
-
-                QQC2.Label {
-                    text: {
-                        if (delegateRoot.runtimeType === "proton") {
-                            var parts = delegateRoot.protonPath.split("/");
-                            return parts[parts.length - 1];
-                        }
-                        return i18n("Wine");
-                    }
-                    font.pixelSize: 10 * gridView.scaleFactor
-                    color: Kirigami.Theme.disabledTextColor
-                    elide: Text.ElideRight
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignBottom
-                    Layout.fillWidth: true
-                    maximumLineCount: 1
                 }
             }
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -92,11 +92,15 @@ Kirigami.ApplicationWindow {
                 onClicked: addDialog.openForNew()
             }
             QQC2.Button {
-                icon.name: "media-playback-start"
+                property bool isRunning: gridView.selectedIndex >= 0 && launcher.runningExePaths.indexOf(appModel.getApp(gridView.selectedIndex).exePath) >= 0
+                icon.name: isRunning ? "media-playback-stop" : "media-playback-start"
                 enabled: gridView.selectedIndex >= 0
                 onClicked: {
                     var app = appModel.getApp(gridView.selectedIndex);
-                    launcher.launchEntry(app);
+                    if (isRunning)
+                        launcher.stopEntry(app);
+                    else
+                        launcher.launchEntry(app);
                 }
             }
         }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -220,6 +220,16 @@ Kirigami.ApplicationWindow {
         }
     }
 
+    function openExe(path) {
+        var existing = appModel.getAppByExePath(path);
+        if (existing && existing.exePath !== undefined) {
+            launcher.launchEntry(existing);
+        } else {
+            openExeChoiceDialog.exePath = path;
+            openExeChoiceDialog.open();
+        }
+    }
+
     DropArea {
         anchors.fill: parent
         onDropped: function (drop) {
@@ -229,25 +239,20 @@ Kirigami.ApplicationWindow {
             } else if (drop.hasText) {
                 path = decodeURIComponent(drop.text.trim().replace("file://", ""));
             }
-            if (path !== "") {
-                openExeChoiceDialog.exePath = path;
-                openExeChoiceDialog.open();
-            }
+            if (path !== "")
+                root.openExe(path);
         }
     }
 
     Component.onCompleted: {
-        if (typeof openExePath !== "undefined" && openExePath !== "") {
-            openExeChoiceDialog.exePath = openExePath;
-            openExeChoiceDialog.open();
-        }
+        if (typeof openExePath !== "undefined" && openExePath !== "")
+            root.openExe(openExePath);
     }
 
     Connections {
         target: singleInstance
         function onOpenExeRequested(path) {
-            openExeChoiceDialog.exePath = path;
-            openExeChoiceDialog.open();
+            root.openExe(path);
         }
         function onRaiseRequested() {
             root.raise();

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -13,17 +13,36 @@ Kirigami.PromptDialog {
     onAccepted: {
         settingsManager.setUmuPath(umuPathField.text);
         settingsManager.setDefaultPrefixDir(prefixDirField.text);
+        settingsManager.setDefaultGamePrefix(gamePrefixField.text);
         defaultRuntimePicker.saveToSettings();
+        var vars = [];
+        for (var i = 0; i < envModel.count; i++) {
+            var k = envModel.get(i).key.trim();
+            var v = envModel.get(i).value.trim();
+            if (k !== "")
+                vars.push(k + "=" + v);
+        }
+        settingsManager.setGlobalEnvVars(vars);
     }
 
     function openDialog() {
         umuPathField.text = settingsManager.umuPath;
         prefixDirField.text = settingsManager.defaultPrefixDir;
+        gamePrefixField.text = settingsManager.defaultGamePrefix;
         pathsModel.clear();
         var paths = settingsManager.extraProtonPaths;
         for (var i = 0; i < paths.length; i++) {
             pathsModel.append({
                 "path": paths[i]
+            });
+        }
+        envModel.clear();
+        var vars = settingsManager.globalEnvVars;
+        for (var j = 0; j < vars.length; j++) {
+            var sep = vars[j].indexOf("=");
+            envModel.append({
+                "key": sep > 0 ? vars[j].substring(0, sep) : vars[j],
+                "value": sep > 0 ? vars[j].substring(sep + 1) : ""
             });
         }
         defaultRuntimePicker.reset();
@@ -32,6 +51,10 @@ Kirigami.PromptDialog {
 
     ListModel {
         id: pathsModel
+    }
+
+    ListModel {
+        id: envModel
     }
 
     ColumnLayout {
@@ -94,7 +117,7 @@ Kirigami.PromptDialog {
             }
 
             RowLayout {
-                Kirigami.FormData.label: i18n("Default Prefix Folder:")
+                Kirigami.FormData.label: i18n("Default Prefix Parent Folder:")
                 QQC2.TextField {
                     id: prefixDirField
                     Layout.fillWidth: true
@@ -104,6 +127,39 @@ Kirigami.PromptDialog {
                     icon.name: "document-open"
                     onClicked: prefixDirFolderDialog.open()
                 }
+            }
+
+            QQC2.Label {
+                Kirigami.FormData.label: ""
+                text: i18n("This is the folder where Vermouth stores all the created prefixes by default.")
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+                Layout.maximumWidth: Kirigami.Units.gridUnit * 26
+                font.italic: true
+                opacity: 0.8
+            }
+
+            RowLayout {
+                Kirigami.FormData.label: i18n("Default App/Game Prefix:")
+                QQC2.TextField {
+                    id: gamePrefixField
+                    Layout.fillWidth: true
+                    placeholderText: i18n("Auto-generate per app/game")
+                }
+                QQC2.Button {
+                    icon.name: "document-open"
+                    onClicked: gamePrefixFolderDialog.open()
+                }
+            }
+
+            QQC2.Label {
+                Kirigami.FormData.label: ""
+                text: i18n("Set this if you want all apps and games to share a single prefix (e.g. one Wine/Proton environment for everything). Leave empty to auto-generate a separate prefix per game. You can still use separate prefixe per game, but you have to set it explicitly.")
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+                Layout.maximumWidth: Kirigami.Units.gridUnit * 26
+                font.italic: true
+                opacity: 0.8
             }
 
             Kirigami.Separator {
@@ -163,6 +219,51 @@ Kirigami.PromptDialog {
                     onClicked: protonPathFolderDialog.open()
                 }
             }
+
+            Kirigami.Separator {
+                Kirigami.FormData.isSection: true
+                Kirigami.FormData.label: i18n("Global Environment Variables")
+            }
+
+            ColumnLayout {
+                Kirigami.FormData.label: i18n("Applied to every game. Per-game launch options can override these.")
+                Layout.fillWidth: true
+
+                Repeater {
+                    model: envModel
+                    delegate: RowLayout {
+                        Layout.fillWidth: true
+                        QQC2.TextField {
+                            placeholderText: i18n("KEY")
+                            text: model.key
+                            implicitWidth: Kirigami.Units.gridUnit * 9
+                            onTextChanged: envModel.setProperty(index, "key", text)
+                        }
+                        QQC2.Label {
+                            text: "="
+                        }
+                        QQC2.TextField {
+                            placeholderText: i18n("value")
+                            text: model.value
+                            Layout.fillWidth: true
+                            onTextChanged: envModel.setProperty(index, "value", text)
+                        }
+                        QQC2.Button {
+                            icon.name: "list-remove"
+                            onClicked: envModel.remove(index)
+                        }
+                    }
+                }
+
+                QQC2.Button {
+                    text: i18n("Add Variable")
+                    icon.name: "list-add"
+                    onClicked: envModel.append({
+                        "key": "",
+                        "value": ""
+                    })
+                }
+            }
         }
     }
 
@@ -178,6 +279,13 @@ Kirigami.PromptDialog {
         title: i18n("Select Default Prefix Folder")
         currentFolder: "file://" + protonScanner.homePath()
         onAccepted: prefixDirField.text = decodeURIComponent(selectedFolder.toString().replace("file://", ""))
+    }
+
+    FolderDialog {
+        id: gamePrefixFolderDialog
+        title: i18n("Select Default App/Game Prefix")
+        currentFolder: "file://" + protonScanner.prefixBasePath()
+        onAccepted: gamePrefixField.text = decodeURIComponent(selectedFolder.toString().replace("file://", ""))
     }
 
     FolderDialog {

--- a/src/appmodel.cpp
+++ b/src/appmodel.cpp
@@ -251,6 +251,30 @@ QVariantMap AppModel::getAppById(const QString &id) const
     return {};
 }
 
+QVariantMap AppModel::getAppByExePath(const QString &exePath) const
+{
+    for (int i = 0; i < m_entries.size(); ++i) {
+        if (m_entries[i].exePath == exePath) {
+            // Return via getApp using a filtered index isn't safe here; build map directly.
+            const auto &e = m_entries[i];
+            return {
+                {QStringLiteral("id"), e.id},
+                {QStringLiteral("name"), e.name},
+                {QStringLiteral("exePath"), e.exePath},
+                {QStringLiteral("runtimeType"), (e.runtimeType == AppEntry::Proton) ? QStringLiteral("proton") : QStringLiteral("wine")},
+                {QStringLiteral("protonPath"), e.protonPath},
+                {QStringLiteral("protonPrefix"), e.protonPrefix},
+                {QStringLiteral("wineBinary"), e.wineBinary},
+                {QStringLiteral("winePrefix"), e.winePrefix},
+                {QStringLiteral("iconPath"), e.iconPath},
+                {QStringLiteral("launchOptions"), e.launchOptions},
+                {QStringLiteral("enableLogging"), e.enableLogging},
+            };
+        }
+    }
+    return {};
+}
+
 void AppModel::load()
 {
     QFile f(configPath());

--- a/src/appmodel.h
+++ b/src/appmodel.h
@@ -60,6 +60,7 @@ public:
                              bool enableLogging = false);
     Q_INVOKABLE QVariantMap getApp(int index) const;
     Q_INVOKABLE QVariantMap getAppById(const QString &id) const;
+    Q_INVOKABLE QVariantMap getAppByExePath(const QString &exePath) const;
     Q_INVOKABLE void setFilterString(const QString &filter);
 
     void load();

--- a/src/launcher.cpp
+++ b/src/launcher.cpp
@@ -87,8 +87,14 @@ void Launcher::launch(const QString &binary,
                       const QString &logName)
 {
     auto *proc = new QProcess(this);
-    connect(proc, &QProcess::finished, proc, &QProcess::deleteLater);
-    connect(proc, &QProcess::finished, this, &Launcher::processFinished);
+    m_runningProcesses.insert(exePath, proc);
+    Q_EMIT runningExePathsChanged();
+    connect(proc, &QProcess::finished, this, [this, exePath, proc](int exitCode) {
+        m_runningProcesses.remove(exePath);
+        Q_EMIT runningExePathsChanged();
+        Q_EMIT processFinished(exitCode);
+        proc->deleteLater();
+    });
 
     proc->setProcessEnvironment(env);
     proc->setWorkingDirectory(QFileInfo(exePath).absolutePath());
@@ -116,6 +122,8 @@ void Launcher::launch(const QString &binary,
     }
 
     if (!proc->waitForStarted(5000)) {
+        m_runningProcesses.remove(exePath);
+        Q_EMIT runningExePathsChanged();
         Q_EMIT launchError(exePath, proc->errorString());
         proc->deleteLater();
     } else {
@@ -172,6 +180,13 @@ void Launcher::launchEntry(const QVariantMap &app)
         }
         launch(app[QStringLiteral("wineBinary")].toString(), {}, exePath, env, opts, logging, name);
     }
+}
+
+void Launcher::stopEntry(const QVariantMap &app)
+{
+    QProcess *proc = m_runningProcesses.value(app[QStringLiteral("exePath")].toString(), nullptr);
+    if (proc)
+        proc->terminate();
 }
 
 void Launcher::runInPrefix(const QVariantMap &app, const QString &exePath)
@@ -317,7 +332,19 @@ void Launcher::toggleHdr()
     QString screenName = currentScreenName();
     QString action = enable ? QStringLiteral("hdr.enable") : QStringLiteral("hdr.disable");
     QProcess::execute(kscreenDoctorBin(), kscreenDoctorArgs({QStringLiteral("output.") + screenName + QLatin1Char('.') + action}));
+    if (enable)
+        m_hdrEnabledByUs = true;
+    else
+        m_hdrEnabledByUs = false;
     refreshHdrState();
+}
+
+void Launcher::restoreHdrState()
+{
+    if (!m_hdrEnabledByUs)
+        return;
+    QString screenName = currentScreenName();
+    QProcess::execute(kscreenDoctorBin(), kscreenDoctorArgs({QStringLiteral("output.") + screenName + QStringLiteral(".hdr.disable")}));
 }
 
 void Launcher::setupLogging(QProcess *proc, const QString &name)

--- a/src/launcher.cpp
+++ b/src/launcher.cpp
@@ -61,6 +61,11 @@ void Launcher::setUmuPath(const QString &path)
     m_umuPath = path;
 }
 
+void Launcher::setGlobalEnvVars(const QStringList &vars)
+{
+    m_globalEnvVars = vars;
+}
+
 QString Launcher::logDir() const
 {
     return m_logDir;
@@ -126,6 +131,12 @@ void Launcher::launchEntry(const QVariantMap &app)
     QString name = app[QStringLiteral("name")].toString();
 
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+
+    for (const QString &kv : std::as_const(m_globalEnvVars)) {
+        int sep = kv.indexOf(QLatin1Char('='));
+        if (sep > 0)
+            env.insert(kv.left(sep), kv.mid(sep + 1));
+    }
 
     if (m_hdrEnabled) {
         env.insert(QStringLiteral("PROTON_ENABLE_HDR"), QStringLiteral("1"));

--- a/src/launcher.h
+++ b/src/launcher.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <QDBusUnixFileDescriptor>
+#include <QHash>
 #include <QObject>
 #include <QProcess>
 #include <QProcessEnvironment>
+#include <QStringList>
 
 class Launcher : public QObject
 {
@@ -15,7 +17,14 @@ public:
     void setUmuPath(const QString &path);
     void setGlobalEnvVars(const QStringList &vars);
 
+    Q_PROPERTY(QStringList runningExePaths READ runningExePaths NOTIFY runningExePathsChanged)
+    QStringList runningExePaths() const
+    {
+        return m_runningProcesses.keys();
+    }
+
     Q_INVOKABLE void launchEntry(const QVariantMap &app);
+    Q_INVOKABLE void stopEntry(const QVariantMap &app);
     Q_INVOKABLE void runInPrefix(const QVariantMap &app, const QString &exePath);
     Q_INVOKABLE void runWinecfg(const QVariantMap &app);
     Q_INVOKABLE void runRegedit(const QVariantMap &app);
@@ -30,6 +39,7 @@ public:
     Q_PROPERTY(bool hdrEnabled READ hdrEnabled NOTIFY hdrEnabledChanged)
     Q_PROPERTY(bool hdrSupported READ hdrSupported NOTIFY hdrSupportedChanged)
     Q_INVOKABLE void toggleHdr();
+    void restoreHdrState();
     bool hdrEnabled() const;
     bool hdrSupported() const;
 
@@ -38,6 +48,7 @@ Q_SIGNALS:
     void launchError(const QString &name, const QString &error);
     void prefixNotReady(const QString &name);
     void processFinished(int exitCode);
+    void runningExePathsChanged();
     void sleepInhibitedChanged();
     void hdrEnabledChanged();
     void hdrSupportedChanged();
@@ -55,7 +66,9 @@ private:
     QString m_logDir;
     QString m_umuPath;
     QStringList m_globalEnvVars;
+    QHash<QString, QProcess *> m_runningProcesses;
     int m_inhibitFd = -1;
     bool m_hdrEnabled = false;
     bool m_hdrSupported = false;
+    bool m_hdrEnabledByUs = false;
 };

--- a/src/launcher.h
+++ b/src/launcher.h
@@ -13,6 +13,7 @@ public:
     explicit Launcher(QObject *parent = nullptr);
 
     void setUmuPath(const QString &path);
+    void setGlobalEnvVars(const QStringList &vars);
 
     Q_INVOKABLE void launchEntry(const QVariantMap &app);
     Q_INVOKABLE void runInPrefix(const QVariantMap &app, const QString &exePath);
@@ -53,6 +54,7 @@ private:
     void refreshHdrState();
     QString m_logDir;
     QString m_umuPath;
+    QStringList m_globalEnvVars;
     int m_inhibitFd = -1;
     bool m_hdrEnabled = false;
     bool m_hdrSupported = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,6 +146,10 @@ int main(int argc, char *argv[])
     QObject::connect(&settingsManager, &SettingsManager::globalEnvVarsChanged, [&]() {
         launcher.setGlobalEnvVars(settingsManager.globalEnvVars());
     });
+
+    QObject::connect(&app, &QApplication::aboutToQuit, [&]() {
+        launcher.restoreHdrState();
+    });
     QObject::connect(&umuDownloader, &UmuDownloader::finished, [&](const QString &binPath) {
         settingsManager.setUmuPath(binPath);
     });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,6 +141,11 @@ int main(int argc, char *argv[])
     QObject::connect(&settingsManager, &SettingsManager::umuPathChanged, [&]() {
         launcher.setUmuPath(settingsManager.umuPath());
     });
+
+    launcher.setGlobalEnvVars(settingsManager.globalEnvVars());
+    QObject::connect(&settingsManager, &SettingsManager::globalEnvVarsChanged, [&]() {
+        launcher.setGlobalEnvVars(settingsManager.globalEnvVars());
+    });
     QObject::connect(&umuDownloader, &UmuDownloader::finished, [&](const QString &binPath) {
         settingsManager.setUmuPath(binPath);
     });

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -18,6 +18,19 @@ void SettingsManager::setDefaultPrefixDir(const QString &path)
     Q_EMIT defaultPrefixDirChanged();
 }
 
+QString SettingsManager::defaultGamePrefix() const
+{
+    return m_settings.value(QStringLiteral("defaultGamePrefix")).toString();
+}
+
+void SettingsManager::setDefaultGamePrefix(const QString &path)
+{
+    if (defaultGamePrefix() == path)
+        return;
+    m_settings.setValue(QStringLiteral("defaultGamePrefix"), path);
+    Q_EMIT defaultGamePrefixChanged();
+}
+
 QStringList SettingsManager::extraProtonPaths() const
 {
     return m_settings.value(QStringLiteral("extraProtonPaths")).toStringList();
@@ -97,6 +110,17 @@ void SettingsManager::setUmuPath(const QString &path)
         return;
     m_settings.setValue(QStringLiteral("umuPath"), path);
     Q_EMIT umuPathChanged();
+}
+
+QStringList SettingsManager::globalEnvVars() const
+{
+    return m_settings.value(QStringLiteral("globalEnvVars")).toStringList();
+}
+
+void SettingsManager::setGlobalEnvVars(const QStringList &vars)
+{
+    m_settings.setValue(QStringLiteral("globalEnvVars"), vars);
+    Q_EMIT globalEnvVarsChanged();
 }
 
 bool SettingsManager::drawerPinned() const

--- a/src/settingsmanager.h
+++ b/src/settingsmanager.h
@@ -8,18 +8,23 @@ class SettingsManager : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QString defaultPrefixDir READ defaultPrefixDir WRITE setDefaultPrefixDir NOTIFY defaultPrefixDirChanged)
+    Q_PROPERTY(QString defaultGamePrefix READ defaultGamePrefix WRITE setDefaultGamePrefix NOTIFY defaultGamePrefixChanged)
     Q_PROPERTY(QStringList extraProtonPaths READ extraProtonPaths WRITE setExtraProtonPaths NOTIFY extraProtonPathsChanged)
     Q_PROPERTY(QString defaultRuntimeType READ defaultRuntimeType WRITE setDefaultRuntimeType NOTIFY defaultRuntimeChanged)
     Q_PROPERTY(QString defaultProtonPath READ defaultProtonPath WRITE setDefaultProtonPath NOTIFY defaultRuntimeChanged)
     Q_PROPERTY(QString defaultWineBinary READ defaultWineBinary WRITE setDefaultWineBinary NOTIFY defaultRuntimeChanged)
     Q_PROPERTY(bool drawerPinned READ drawerPinned WRITE setDrawerPinned NOTIFY drawerPinnedChanged)
     Q_PROPERTY(QString umuPath READ umuPath WRITE setUmuPath NOTIFY umuPathChanged)
+    Q_PROPERTY(QStringList globalEnvVars READ globalEnvVars WRITE setGlobalEnvVars NOTIFY globalEnvVarsChanged)
 
 public:
     explicit SettingsManager(QObject *parent = nullptr);
 
     QString defaultPrefixDir() const;
     Q_INVOKABLE void setDefaultPrefixDir(const QString &path);
+
+    QString defaultGamePrefix() const;
+    Q_INVOKABLE void setDefaultGamePrefix(const QString &path);
 
     QStringList extraProtonPaths() const;
     void setExtraProtonPaths(const QStringList &paths);
@@ -42,12 +47,17 @@ public:
     QString umuPath() const;
     Q_INVOKABLE void setUmuPath(const QString &path);
 
+    QStringList globalEnvVars() const;
+    Q_INVOKABLE void setGlobalEnvVars(const QStringList &vars);
+
 Q_SIGNALS:
     void defaultPrefixDirChanged();
+    void defaultGamePrefixChanged();
     void extraProtonPathsChanged();
     void defaultRuntimeChanged();
     void drawerPinnedChanged();
     void umuPathChanged();
+    void globalEnvVarsChanged();
 
 private:
     QSettings m_settings;


### PR DESCRIPTION
- Added support for translations
- Known exe files will be executed in their settings when launched by association. Closes #11 
- The grid has been made tidier. Not showing the runtime, as the runtime is shown below in the status bar, the icon made bigger
- Stop button! Per #8 
- HDR Disable on app close. If HDR was enabled in vermouth, it will get disabled when vermouth closes
- Support for Global env vars per #8 
- Support for a single prefix for all entries, per #8 