### PR TITLE
Steam detector and tips

### DIFF
--- a/po/mk/vermouth.po
+++ b/po/mk/vermouth.po
@@ -625,5 +625,43 @@ msgstr "Изберете папка за скенирање на Proton"
 msgid "Select Background Color"
 msgstr ""
 
+#: po/../qml/Main.qml:75 po/../qml/Main.qml:585 po/../qml/SteamImportDialog.qml:8
+msgid "Import from Steam"
+msgstr "Увези од Steam"
+
+#: po/../qml/Main.qml:580
+msgid "Steam installation detected"
+msgstr "Откриена е инсталација на Steam"
+
+#: po/../qml/Main.qml:581
+msgid ""
+"Vermouth found a Steam installation on your system. Would you like to import "
+"some games from your Steam library now?"
+msgstr ""
+"Vermouth пронајде инсталација на Steam на вашиот систем. Дали сакате сега да "
+"увезете некои игри од вашата Steam библиотека?"
+
+#: po/../qml/Main.qml:593
+msgid "Not now"
+msgstr "Не сега"
+
+#: po/../qml/Main.qml:600
+msgid "Don't show me tips"
+msgstr "Не ми прикажувај совети"
+
+#: po/../qml/SettingsDialog.qml:534
+msgid "Tips"
+msgstr "Совети"
+
+#: po/../qml/SettingsDialog.qml:539
+msgid "Show Tips:"
+msgstr "Прикажувај совети:"
+
+#: po/../qml/SettingsDialog.qml:545
+msgid "Show helpful prompts like the Steam import suggestion on first launch"
+msgstr ""
+"Прикажувај корисни предлози и совети "
+
+
 #~ msgid "Run Standalone EXE"
 #~ msgstr "Стартување на самостоен EXE"

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -576,6 +576,34 @@ Kirigami.ApplicationWindow {
     }
 
     Kirigami.PromptDialog {
+        id: steamFoundDialog
+        title: i18n("Steam installation detected")
+        subtitle: i18n("Vermouth found a Steam installation on your system. Would you like to import some games from your Steam library now?")
+        standardButtons: Kirigami.Dialog.NoButton
+        customFooterActions: [
+            Kirigami.Action {
+                text: i18n("Import from Steam")
+                icon.name: "steam"
+                onTriggered: {
+                    steamFoundDialog.close();
+                    steamImportDialog.openDialog();
+                }
+            },
+            Kirigami.Action {
+                text: i18n("Not now")
+                icon.name: "dialog-cancel"
+                onTriggered: steamFoundDialog.close();
+            }
+        ]
+
+        QQC2.CheckBox {
+            text: i18n("Don't show me tips")
+            checked: !settingsManager.showTips
+            onToggled: settingsManager.setShowTips(!checked)
+        }
+    }
+
+    Kirigami.PromptDialog {
         id: prefixNotReadyDialog
         property string appName
         title: i18n("Prefix not ready")
@@ -665,6 +693,24 @@ Kirigami.ApplicationWindow {
             bigPictureAction.trigger();
         if (typeof openExePath !== "undefined" && openExePath !== "")
             root.openExe(openExePath);
+        else
+            maybeOfferSteamImport();
+    }
+
+    function maybeOfferSteamImport() {
+        var firstRun = !settingsManager.firstRunComplete;
+        settingsManager.setFirstRunComplete(true);
+        if (!firstRun)
+            return;
+        if (root.bigPicture)
+            return;
+        if (!settingsManager.showTips)
+            return;
+        if (appModel.count > 0)
+            return;
+        if (!steamModel.isSteamInstalled())
+            return;
+        steamFoundDialog.open();
     }
 
     Connections {

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -531,6 +531,26 @@ Kirigami.PromptDialog {
 
             Kirigami.Separator {
                 Kirigami.FormData.isSection: true
+                Kirigami.FormData.label: i18n("Tips")
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Kirigami.FormData.label: i18n("Show Tips:")
+                QQC2.Switch {
+                    checked: settingsManager.showTips
+                    onToggled: settingsManager.setShowTips(checked)
+                }
+                QQC2.Label {
+                    text: i18n("Show helpful prompts like the Steam import suggestion on first launch")
+                    wrapMode: Text.WordWrap
+                    font.pointSize: Kirigami.Theme.defaultFont.pointSize - 2
+                    color: Kirigami.Theme.disabledTextColor
+                }
+            }
+
+            Kirigami.Separator {
+                Kirigami.FormData.isSection: true
                 Kirigami.FormData.label: i18n("Gamepad")
             }
 

--- a/src/settingsmanager.cpp
+++ b/src/settingsmanager.cpp
@@ -285,6 +285,32 @@ void SettingsManager::setRomCacheDir(const QString &dir)
     Q_EMIT romCacheDirChanged();
 }
 
+bool SettingsManager::firstRunComplete() const
+{
+    return m_settings.value(QStringLiteral("firstRunComplete"), false).toBool();
+}
+
+void SettingsManager::setFirstRunComplete(bool complete)
+{
+    if (firstRunComplete() == complete)
+        return;
+    m_settings.setValue(QStringLiteral("firstRunComplete"), complete);
+    Q_EMIT firstRunCompleteChanged();
+}
+
+bool SettingsManager::showTips() const
+{
+    return m_settings.value(QStringLiteral("showTips"), true).toBool();
+}
+
+void SettingsManager::setShowTips(bool enabled)
+{
+    if (showTips() == enabled)
+        return;
+    m_settings.setValue(QStringLiteral("showTips"), enabled);
+    Q_EMIT showTipsChanged();
+}
+
 QVariantMap SettingsManager::rommCoreMap() const
 {
     QString json = m_settings.value(QStringLiteral("rommCoreMap")).toString();

--- a/src/settingsmanager.h
+++ b/src/settingsmanager.h
@@ -27,6 +27,8 @@ class SettingsManager : public QObject
     Q_PROPERTY(QString rommApiKey READ rommApiKey WRITE setRommApiKey NOTIFY rommApiKeyChanged)
     Q_PROPERTY(QString retroarchPath READ retroarchPath WRITE setRetroarchPath NOTIFY retroarchPathChanged)
     Q_PROPERTY(QString romCacheDir READ romCacheDir WRITE setRomCacheDir NOTIFY romCacheDirChanged)
+    Q_PROPERTY(bool firstRunComplete READ firstRunComplete WRITE setFirstRunComplete NOTIFY firstRunCompleteChanged)
+    Q_PROPERTY(bool showTips READ showTips WRITE setShowTips NOTIFY showTipsChanged)
 
 public:
     explicit SettingsManager(QObject *parent = nullptr);
@@ -91,6 +93,12 @@ public:
     QString romCacheDir() const;
     Q_INVOKABLE void setRomCacheDir(const QString &dir);
 
+    bool firstRunComplete() const;
+    Q_INVOKABLE void setFirstRunComplete(bool complete);
+
+    bool showTips() const;
+    Q_INVOKABLE void setShowTips(bool enabled);
+
     QVariantMap rommCoreMap() const;
     Q_INVOKABLE QString rommCore(const QString &platformSlug) const;
     Q_INVOKABLE void setRommCore(const QString &platformSlug, const QString &corePath);
@@ -118,6 +126,8 @@ Q_SIGNALS:
     void rommApiKeyChanged();
     void retroarchPathChanged();
     void romCacheDirChanged();
+    void firstRunCompleteChanged();
+    void showTipsChanged();
     void rommCoreMapChanged();
     void rommGameCoreMapChanged();
 

--- a/src/steammodel.cpp
+++ b/src/steammodel.cpp
@@ -97,6 +97,11 @@ void SteamModel::scanLibraries()
     watcher->setFuture(QtConcurrent::run(&SteamLibrary::scan));
 }
 
+bool SteamModel::isSteamInstalled() const
+{
+    return !SteamLibrary::steamRootPaths().isEmpty();
+}
+
 QVariantMap SteamModel::getGame(int index) const
 {
     if (index < 0 || index >= m_entries.size())

--- a/src/steammodel.h
+++ b/src/steammodel.h
@@ -34,6 +34,7 @@ public:
 
     Q_INVOKABLE void scanLibraries();
     Q_INVOKABLE QVariantMap getGame(int index) const;
+    Q_INVOKABLE bool isSteamInstalled() const;
 
 Q_SIGNALS:
     void countChanged();

--- a/testrun.sh
+++ b/testrun.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Run the current build against a throwaway XDG config so the live library
+# and settings are untouched. The temp dir is removed when the app exits.
+# Може имаш ова некаде ама не видов така да бујрум!
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="$SCRIPT_DIR/build/bin/vermouth"
+
+if [ ! -x "$BIN" ]; then
+    echo "Error: $BIN not found. Build first: cmake -B build && cmake --build build" >&2
+    exit 1
+fi
+
+TMPCFG=$(mktemp -d -t vermouth-test-XXXXXX)
+trap 'rm -rf "$TMPCFG"' EXIT
+
+echo "Config dir: $TMPCFG"
+XDG_CONFIG_HOME="$TMPCFG" XDG_DATA_HOME="$TMPCFG/data" "$BIN" "$@"


### PR DESCRIPTION
- Added tips for new users
- Tips can be disabled from any tip dialog or from the Settings of Vermouth
- Added a steam installation detector that checks if steam is installed
- Added an initial tip for first time start of empty library to suggest importing from steam
- Added relevant Macedonian translations 
- Added a disable tips option in the settings (last option before gamepad settings thingie)