### PR TITLE
desktopfilewriter: use binary name only when generating desktop files

### DIFF
--- a/src/desktopfilewriter.cpp
+++ b/src/desktopfilewriter.cpp
@@ -25,7 +25,7 @@ bool DesktopFileWriter::writeDesktopFile(const QString &filePath, const QVariant
     QString id = app[QStringLiteral("id")].toString();
 
     QString exec = isInsideFlatpak() ? QStringLiteral("flatpak run com.dekomote.vermouth --launch-id %1").arg(id)
-                                     : QStringLiteral("'%1' --launch-id \"%2\"").arg(QCoreApplication::applicationFilePath(), id);
+                                     : QStringLiteral("vermouth --launch-id %1").arg(id);
 
     QFile f(filePath);
     if (!f.open(QIODevice::WriteOnly | QIODevice::Text))


### PR DESCRIPTION
Full file paths should generally not be used in desktop entries. Also, remove unnecessary quoting on `id`.