### PR TITLE
Lights out rewrite

### DIFF
--- a/qml/GameCardFrame.qml
+++ b/qml/GameCardFrame.qml
@@ -144,7 +144,6 @@ Item {
             QQC2.Label {
                 text: frameRoot.displayName
                 visible: frameRoot.gv && frameRoot.gv.showNames
-                color: frameRoot.gv && frameRoot.gv.lightsOut ? "#ffffff" : Kirigami.Theme.textColor
                 font.pixelSize: 12 * frameRoot.gv.scaleFactor
                 font.bold: true
                 elide: Text.ElideRight

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -406,10 +406,20 @@ Kirigami.ApplicationWindow {
                         root.visibility = Window.FullScreen;
                         settingsManager.setLightsOut(true);
                         gridView.scaleFactor = 1.5;
+                        root.prevDrawerPinned = settingsManager.drawerPinned;
+                        if (settingsManager.drawerPinned) {
+                            settingsManager.setDrawerPinned(false);
+                            globalDrawer.close();
+                        }
                     } else {
                         root.visibility = Window.Windowed;
                         settingsManager.setLightsOut(root.prevLightsOut);
                         gridView.scaleFactor = root.prevScaleFactor;
+                        if (root.prevDrawerPinned) {
+                            settingsManager.setDrawerPinned(true);
+                            if (root.wideScreen)
+                                Qt.callLater(() => globalDrawer.open());
+                        }
                     }
                     settingsManager.setBigPicture(!root.bigPicture);
                 }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -160,19 +160,7 @@ Kirigami.ApplicationWindow {
     onHeightChanged: if (visibility === Window.Windowed)
         windowSettings.savedHeight = height
 
-    onLightsOutChanged: {
-        if (root.lightsOut) {
-            root.prevDrawerPinned = settingsManager.drawerPinned;
-            if (settingsManager.drawerPinned) {
-                settingsManager.setDrawerPinned(false);
-                globalDrawer.close();
-            }
-        } else if (root.prevDrawerPinned) {
-            settingsManager.setDrawerPinned(true);
-            if (root.wideScreen)
-                Qt.callLater(() => globalDrawer.open());
-        }
-    }
+    onLightsOutChanged: {}
 
     globalDrawer: Kirigami.GlobalDrawer {
         id: globalDrawer
@@ -182,11 +170,9 @@ Kirigami.ApplicationWindow {
         interactiveResizeEnabled: true
         Component.onCompleted: preferredSize = sidebarSettings.width > 0 ? sidebarSettings.width : Kirigami.Units.gridUnit * 14
         onPreferredSizeChanged: sidebarSettings.width = preferredSize
-
         header: Kirigami.AbstractApplicationHeader {
             visible: root.sidebarPinned
             preferredHeight: root.headerHeight
-
             contentItem: RowLayout {
                 spacing: 0
                 anchors {
@@ -405,6 +391,7 @@ Kirigami.ApplicationWindow {
             Kirigami.Action {
                 text: root.lightsOut ? i18n("Lights On") : i18n("Lights Out")
                 icon.name: root.lightsOut ? "weather-clear-symbolic" : "weather-clear-night-symbolic"
+                enabled: lightsOutSupported
                 onTriggered: settingsManager.setLightsOut(!root.lightsOut)
             },
             Kirigami.Action {
@@ -470,8 +457,6 @@ Kirigami.ApplicationWindow {
                     focusPolicy: Qt.NoFocus
                     checkable: true
                     checked: settingsManager.drawerPinned
-                    // Pinning is a light-mode feature; disabled while in dark mode.
-                    enabled: !root.lightsOut
                     flat: true
                     onClicked: settingsManager.setDrawerPinned(!settingsManager.drawerPinned)
                     QQC2.ToolTip.text: settingsManager.drawerPinned ? i18n("Unpin sidebar") : i18n("Pin sidebar")

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -17,16 +17,6 @@ Kirigami.ApplicationWindow {
     // Lights Out computed colors
     readonly property bool lightsOut: settingsManager.lightsOut
     readonly property bool bigPicture: settingsManager.bigPicture
-    readonly property color loBase: Qt.color(settingsManager.lightsOutColor)
-    readonly property color loDark: Qt.darker(loBase, 1.5)
-    readonly property color loDarkest: Qt.darker(loBase, 2)
-    readonly property color loMid: Qt.darker(loBase, 1.2)
-    readonly property color loHighlight: Qt.lighter(loBase, 1.8)
-    readonly property color loText: "#ffffff"
-    readonly property color loSubText: Qt.rgba(1, 1, 1, 0.6)
-    readonly property color loAltBg: Qt.darker(loBase, 1.3)
-    Kirigami.Theme.colorSet: lightsOut ? Kirigami.Theme.Complementary : Kirigami.Theme.Window
-    Kirigami.Theme.inherit: false
 
     property double prevScaleFactor: 1
     property bool prevLightsOut: false
@@ -184,10 +174,6 @@ Kirigami.ApplicationWindow {
         }
     }
 
-    background: Rectangle {
-        color: root.lightsOut ? root.loBase : Kirigami.Theme.backgroundColor
-    }
-
     globalDrawer: Kirigami.GlobalDrawer {
         id: globalDrawer
         modal: !settingsManager.drawerPinned || !root.wideScreen
@@ -197,17 +183,9 @@ Kirigami.ApplicationWindow {
         Component.onCompleted: preferredSize = sidebarSettings.width > 0 ? sidebarSettings.width : Kirigami.Units.gridUnit * 14
         onPreferredSizeChanged: sidebarSettings.width = preferredSize
 
-        Kirigami.Theme.inherit: root.lightsOut
-        Kirigami.Theme.colorSet: modal ? Kirigami.Theme.Window : Kirigami.Theme.View
-
         header: Kirigami.AbstractApplicationHeader {
             visible: root.sidebarPinned
             preferredHeight: root.headerHeight
-            Kirigami.Theme.colorSet: root.lightsOut ? Kirigami.Theme.Complementary : Kirigami.Theme.Header
-            Kirigami.Theme.inherit: false
-            background: Rectangle {
-                color: root.lightsOut ? root.loMid : Kirigami.Theme.backgroundColor
-            }
 
             contentItem: RowLayout {
                 spacing: 0
@@ -222,7 +200,6 @@ Kirigami.ApplicationWindow {
                     focusPolicy: Qt.NoFocus
                     readonly property var viewOrder: ["icon", "grid", "hero"]
                     icon.name: viewMenu.viewIcons[gridView.viewType]
-                    icon.color: root.lightsOut ? root.loText : Kirigami.Theme.textColor
                     onClicked: gridView.viewType = viewOrder[(viewOrder.indexOf(gridView.viewType) + 1) % viewOrder.length]
                     QQC2.ToolTip.text: i18n("Switch view type")
                     QQC2.ToolTip.visible: hovered
@@ -234,7 +211,6 @@ Kirigami.ApplicationWindow {
                     icon.name: "go-down-symbolic"
                     icon.width: Kirigami.Units.iconSizes.small
                     icon.height: Kirigami.Units.iconSizes.small
-                    icon.color: root.lightsOut ? root.loText : Kirigami.Theme.textColor
                     onClicked: viewMenu.popup(viewIconBtn, 0, viewIconBtn.height)
                     QQC2.ToolTip.text: i18n("Switch view type")
                     QQC2.ToolTip.visible: hovered
@@ -521,20 +497,6 @@ Kirigami.ApplicationWindow {
                 bottomPadding: Kirigami.Units.largeSpacing
                 leftPadding: Kirigami.Units.largeSpacing
                 rightPadding: Kirigami.Units.largeSpacing
-                background: Rectangle {
-                    color: root.lightsOut ? root.loMid : Kirigami.Theme.backgroundColor
-                }
-                // AppImage hack
-                palette.highlightedText: root.lightsOut ? root.loText : undefined
-                palette.button: root.lightsOut ? root.loMid : undefined
-                palette.buttonText: root.lightsOut ? root.loText : undefined
-                palette.window: root.lightsOut ? root.loBase : undefined
-                palette.windowText: root.lightsOut ? root.loText : undefined
-                palette.base: root.lightsOut ? root.loBase : undefined
-                palette.text: root.lightsOut ? root.loText : undefined
-                palette.placeholderText: root.lightsOut ? root.loSubText : undefined
-                palette.brightText: root.lightsOut ? root.loText : undefined
-
                 contentItem: RowLayout {
                     spacing: Kirigami.Units.mediumSpacing
                     QQC2.ToolButton {
@@ -542,7 +504,6 @@ Kirigami.ApplicationWindow {
                         focusPolicy: Qt.NoFocus
                         visible: globalDrawer.modal
                         onClicked: globalDrawer.open()
-                        icon.color: root.lightsOut ? root.loText : Kirigami.Theme.textColor
                     }
 
                     QQC2.ToolButton {
@@ -551,7 +512,6 @@ Kirigami.ApplicationWindow {
                         focusPolicy: Qt.NoFocus
                         visible: globalDrawer.modal
                         onClicked: viewMenu.popup(viewMenuToolbarBtn, 0, viewMenuToolbarBtn.height)
-                        icon.color: root.lightsOut ? root.loText : Kirigami.Theme.textColor
                         QQC2.ToolTip.text: i18n("Switch view type")
                         QQC2.ToolTip.visible: hovered
                         QQC2.ToolTip.delay: Kirigami.Units.toolTipDelay
@@ -562,7 +522,6 @@ Kirigami.ApplicationWindow {
                         focusPolicy: Qt.NoFocus
                         visible: !root.currentPageObject.nav
                         onClicked: root.navigate(root.previousPage)
-                        icon.color: root.lightsOut ? root.loText : Kirigami.Theme.textColor
                         QQC2.ToolTip.text: i18n("Back")
                         QQC2.ToolTip.visible: hovered
                         QQC2.ToolTip.delay: Kirigami.Units.toolTipDelay
@@ -573,7 +532,6 @@ Kirigami.ApplicationWindow {
                         text: root.currentPageObject.name
                         visible: !root.currentPageObject.nav
                         Layout.fillWidth: true
-                        color: root.lightsOut ? root.loText : Kirigami.Theme.textColor
                     }
 
                     Item {
@@ -591,16 +549,6 @@ Kirigami.ApplicationWindow {
                         onTextChanged: root.updateSearch(text)
                         onVisibleChanged: if (visible)
                             text = Qt.binding(() => root.searchQuery)
-                        Kirigami.Theme.colorSet: Kirigami.Theme.View
-                        Kirigami.Theme.inherit: false
-                        color: root.lightsOut ? root.loText : Kirigami.Theme.textColor
-                        placeholderTextColor: root.lightsOut ? root.loSubText : Kirigami.Theme.disabledTextColor
-                        background: Rectangle {
-                            color: root.lightsOut ? root.loMid : Kirigami.Theme.backgroundColor
-                            radius: Kirigami.Units.cornerRadius
-                            border.width: 1
-                            border.color: searchField.hovered || searchField.activeFocus ? Kirigami.Theme.focusColor : Kirigami.ColorUtils.linearInterpolation(Kirigami.Theme.backgroundColor, Kirigami.Theme.textColor, Kirigami.Theme.frameContrast)
-                        }
                     }
 
                     Item {
@@ -612,7 +560,6 @@ Kirigami.ApplicationWindow {
                         id: addBtn
                         icon.name: "list-add-symbolic"
                         focusPolicy: Qt.NoFocus
-                        icon.color: root.lightsOut ? root.loText : "transparent"
                         visible: !root.bigPicture && root.currentPage === "games" && !root.sidebarPinned
                         onClicked: addDialog.openForNew()
                     }
@@ -624,19 +571,10 @@ Kirigami.ApplicationWindow {
                         textRole: "name"
                         implicitWidth: Kirigami.Units.gridUnit * 12
                         displayText: count > 0 ? currentText : i18n("Select platform…")
-                        Kirigami.Theme.colorSet: Kirigami.Theme.Button
-                        Kirigami.Theme.inherit: false
-                        background: Rectangle {
-                            color: root.lightsOut ? root.loMid : Kirigami.Theme.backgroundColor
-                            radius: Kirigami.Units.cornerRadius
-                            border.width: 1
-                            border.color: rommPlatformCombo.hovered || rommPlatformCombo.popup.visible ? Kirigami.Theme.focusColor : Kirigami.ColorUtils.linearInterpolation(Kirigami.Theme.backgroundColor, Kirigami.Theme.textColor, Kirigami.Theme.frameContrast)
-                        }
                         contentItem: Text {
                             leftPadding: Kirigami.Units.smallSpacing * 2
                             rightPadding: (rommPlatformCombo.indicator ? rommPlatformCombo.indicator.width : 0) + Kirigami.Units.smallSpacing
                             text: rommPlatformCombo.displayText
-                            color: root.lightsOut ? root.loText : Kirigami.Theme.textColor
                             verticalAlignment: Text.AlignVCenter
                             elide: Text.ElideRight
                         }
@@ -666,7 +604,6 @@ Kirigami.ApplicationWindow {
                         visible: !root.bigPicture && root.currentPage === "games"
                         focusPolicy: Qt.NoFocus
                         icon.name: isRunning ? "media-playback-stop-symbolic" : "media-playback-start-symbolic"
-                        icon.color: root.lightsOut ? root.loText : "transparent"
                         enabled: gridView.currentIndex >= 0
                         onClicked: {
                             var app = appModel.getApp(gridView.currentIndex);
@@ -681,8 +618,7 @@ Kirigami.ApplicationWindow {
                         visible: root.currentPage === "settings"
                         focusPolicy: Qt.NoFocus
                         icon.name: "document-save-symbolic"
-                        text: root.lightsOut ? "" : i18n("Save")
-                        icon.color: root.lightsOut ? root.loText : Kirigami.Theme.textColor
+                        text: i18n("Save")
                         onClicked: {
                             settingsPage.save();
                             root.showPassiveNotification(i18n("Settings saved"), 2000);
@@ -696,7 +632,7 @@ Kirigami.ApplicationWindow {
         Rectangle {
             anchors.fill: parent
             Kirigami.Theme.colorSet: settingsManager.gridAltBackground ? Kirigami.Theme.View : Kirigami.Theme.Window
-            color: root.lightsOut ? root.loBase : Kirigami.Theme.backgroundColor
+            color: Kirigami.Theme.backgroundColor
 
             StackLayout {
                 anchors.fill: parent
@@ -729,50 +665,18 @@ Kirigami.ApplicationWindow {
 
                 Kirigami.AboutPage {
                     aboutData: About
-                    Kirigami.Theme.colorSet: root.lightsOut ? Kirigami.Theme.Complementary : Kirigami.Theme.Window
-                    Kirigami.Theme.inherit: false
                 }
 
                 SettingsDialog {
                     id: settingsPage
-                    Kirigami.Theme.colorSet: root.lightsOut ? Kirigami.Theme.Complementary : Kirigami.Theme.Window
-                    Kirigami.Theme.inherit: false
                 }
 
-                WelcomeScreen {
-                    Kirigami.Theme.colorSet: root.lightsOut ? Kirigami.Theme.Complementary : Kirigami.Theme.Window
-                    Kirigami.Theme.inherit: false
-                }
+                WelcomeScreen {}
             }
         }
 
         footer: QQC2.ToolBar {
             position: QQC2.ToolBar.Footer
-            Kirigami.Theme.colorSet: root.lightsOut ? Kirigami.Theme.Complementary : Kirigami.Theme.Window
-            Kirigami.Theme.inherit: false
-            background: Rectangle {
-                color: root.lightsOut ? root.loMid : Kirigami.Theme.backgroundColor
-                Rectangle {
-                    anchors {
-                        left: parent.left
-                        right: parent.right
-                        top: parent.top
-                    }
-                    height: 1
-                    color: root.lightsOut ? Qt.rgba(1, 1, 1, 0.12) : Kirigami.ColorUtils.linearInterpolation(Kirigami.Theme.backgroundColor, Kirigami.Theme.textColor, Kirigami.Theme.frameContrast)
-                }
-            }
-            // AppImage hack
-            palette.highlightedText: root.lightsOut ? root.loText : undefined
-            palette.button: root.lightsOut ? root.loMid : undefined
-            palette.buttonText: root.lightsOut ? root.loText : undefined
-            palette.window: root.lightsOut ? root.loBase : undefined
-            palette.windowText: root.lightsOut ? root.loText : undefined
-            palette.base: root.lightsOut ? root.loBase : undefined
-            palette.text: root.lightsOut ? root.loText : undefined
-            palette.placeholderText: root.lightsOut ? root.loSubText : undefined
-            palette.brightText: root.lightsOut ? root.loText : undefined
-
             contentItem: RowLayout {
                 QQC2.Label {
                     id: footerStatusText
@@ -784,8 +688,6 @@ Kirigami.ApplicationWindow {
                     icon.name: gridView.showHidden ? "view-hidden-symbolic" : "view-visible-symbolic"
                     focusPolicy: Qt.NoFocus
                     onClicked: gridView.showHidden = !gridView.showHidden
-                    // Unfortunately, appimage won't respect the color scheme so I have to improvise:
-                    icon.color: root.lightsOut ? root.loText : (highlighted ? Kirigami.Theme.highlightColor : Kirigami.Theme.textColor)
                     QQC2.ToolTip.text: gridView.showHidden ? i18n("Hide") : i18n("Show Hidden")
                     QQC2.ToolTip.visible: hovered
                     QQC2.ToolTip.delay: Kirigami.Units.toolTipDelay
@@ -796,8 +698,6 @@ Kirigami.ApplicationWindow {
                     checkable: true
                     checked: launcher.sleepInhibited
                     onClicked: launcher.toggleSleepInhibit()
-                    // Unfortunately, appimage won't respect the color scheme so I have to improvise:
-                    icon.color: root.lightsOut ? root.loText : (highlighted ? Kirigami.Theme.highlightColor : Kirigami.Theme.textColor)
                     QQC2.ToolTip.text: launcher.sleepInhibited ? i18n("Allow Sleep") : i18n("Prevent Sleep")
                     QQC2.ToolTip.visible: hovered
                     QQC2.ToolTip.delay: Kirigami.Units.toolTipDelay
@@ -810,7 +710,6 @@ Kirigami.ApplicationWindow {
                     enabled: launcher.hdrSupported
                     visible: launcher.hdrSupported
                     onClicked: launcher.toggleHdr()
-                    icon.color: root.lightsOut ? root.loText : (highlighted ? Kirigami.Theme.highlightColor : Kirigami.Theme.textColor)
                     QQC2.ToolTip.text: launcher.hdrEnabled ? i18n("Disable HDR") : i18n("Enable HDR")
                     QQC2.ToolTip.visible: hovered
                     QQC2.ToolTip.delay: Kirigami.Units.toolTipDelay
@@ -821,7 +720,6 @@ Kirigami.ApplicationWindow {
                     focusPolicy: Qt.NoFocus
                     flat: true
                     highlighted: gridView.viewType === "icon"
-                    icon.color: root.lightsOut ? root.loText : (highlighted ? Kirigami.Theme.highlightColor : Kirigami.Theme.textColor)
                     onClicked: gridView.viewType = "icon"
                     QQC2.ToolTip.text: i18n("Icon view")
                     QQC2.ToolTip.visible: hovered
@@ -832,7 +730,6 @@ Kirigami.ApplicationWindow {
                     focusPolicy: Qt.NoFocus
                     flat: true
                     highlighted: gridView.viewType === "grid"
-                    icon.color: root.lightsOut ? root.loText : (highlighted ? Kirigami.Theme.highlightColor : Kirigami.Theme.textColor)
                     onClicked: gridView.viewType = "grid"
                     QQC2.ToolTip.text: i18n("Cover art view")
                     QQC2.ToolTip.visible: hovered
@@ -843,7 +740,6 @@ Kirigami.ApplicationWindow {
                     focusPolicy: Qt.NoFocus
                     flat: true
                     highlighted: gridView.viewType === "hero"
-                    icon.color: root.lightsOut ? root.loText : (highlighted ? Kirigami.Theme.highlightColor : Kirigami.Theme.textColor)
                     onClicked: gridView.viewType = "hero"
                     QQC2.ToolTip.text: i18n("Hero art view")
                     QQC2.ToolTip.visible: hovered
@@ -854,7 +750,6 @@ Kirigami.ApplicationWindow {
                     focusPolicy: Qt.NoFocus
                     flat: true
                     highlighted: gridView.showNames
-                    icon.color: root.lightsOut ? root.loText : (highlighted ? Kirigami.Theme.highlightColor : Kirigami.Theme.textColor)
                     onClicked: gridView.showNames = !gridView.showNames
                     QQC2.ToolTip.text: gridView.showNames ? i18n("Hide names") : i18n("Show names")
                     QQC2.ToolTip.visible: hovered
@@ -864,7 +759,6 @@ Kirigami.ApplicationWindow {
                     icon.name: "view-sort-symbolic"
                     focusPolicy: Qt.NoFocus
                     flat: true
-                    icon.color: root.lightsOut ? root.loText : Kirigami.Theme.textColor
                     QQC2.ToolTip.text: i18n("Sort By")
                     QQC2.ToolTip.visible: hovered
                     QQC2.ToolTip.delay: Kirigami.Units.toolTipDelay
@@ -919,7 +813,6 @@ Kirigami.ApplicationWindow {
                     flat: true
                     enabled: gridView.scaleFactor > 0.8
                     onClicked: gridView.scaleFactor = Math.max(0.8, gridView.scaleFactor - 0.2)
-                    icon.color: root.lightsOut ? root.loText : Kirigami.Theme.textColor
                 }
                 QQC2.Slider {
                     focusPolicy: Qt.NoFocus
@@ -936,7 +829,6 @@ Kirigami.ApplicationWindow {
                     flat: true
                     enabled: gridView.scaleFactor < 1.8
                     onClicked: gridView.scaleFactor = Math.min(1.8, gridView.scaleFactor + 0.2)
-                    icon.color: root.lightsOut ? root.loText : Kirigami.Theme.textColor
                 }
             }
         }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -160,8 +160,6 @@ Kirigami.ApplicationWindow {
     onHeightChanged: if (visibility === Window.Windowed)
         windowSettings.savedHeight = height
 
-    onLightsOutChanged: {}
-
     globalDrawer: Kirigami.GlobalDrawer {
         id: globalDrawer
         modal: !settingsManager.drawerPinned || !root.wideScreen

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -598,15 +598,23 @@ Kirigami.ScrollablePage {
                 Layout.fillWidth: true
                 Kirigami.FormData.label: i18n("Lights Out:")
                 QQC2.Switch {
-                    checked: settingsManager.lightsOut
+                    enabled: lightsOutSupported
+                    checked: settingsManager.lightsOut && lightsOutSupported
                     onToggled: settingsManager.setLightsOut(checked)
                 }
+            }
+
+            Kirigami.InlineMessage {
+                Layout.fillWidth: true
+                type: Kirigami.MessageType.Warning
+                visible: !lightsOutSupported
+                text: i18n("Lights Out is unavailable with the Adwaita style or when running from an AppImage.")
             }
 
             RowLayout {
                 Layout.fillWidth: true
                 Kirigami.FormData.label: i18n("Background Color:")
-                opacity: settingsManager.lightsOut ? 1.0 : 0.5
+                opacity: settingsManager.lightsOut && lightsOutSupported ? 1.0 : 0.5
 
                 Rectangle {
                     width: Kirigami.Units.gridUnit * 4
@@ -618,7 +626,7 @@ Kirigami.ScrollablePage {
 
                     MouseArea {
                         anchors.fill: parent
-                        enabled: settingsManager.lightsOut
+                        enabled: settingsManager.lightsOut && lightsOutSupported
                         cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                         onClicked: {
                             lightsOutColorDialog.selectedColor = settingsManager.lightsOutColor;
@@ -629,7 +637,7 @@ Kirigami.ScrollablePage {
 
                 QQC2.Button {
                     text: i18n("Reset")
-                    enabled: settingsManager.lightsOut
+                    enabled: settingsManager.lightsOut && lightsOutSupported
                     onClicked: settingsManager.setLightsOutColor("#2A2E32")
                 }
             }

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -608,7 +608,7 @@ Kirigami.ScrollablePage {
                 Layout.fillWidth: true
                 type: Kirigami.MessageType.Warning
                 visible: !lightsOutSupported
-                text: i18n("Lights Out is unavailable with the Adwaita style or when running from an AppImage.")
+                text: i18n("Lights Out is only supported on the KDE Plasma desktop.")
             }
 
             RowLayout {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include <QQuickStyle>
 #include <QStyle>
 #include <QTimer>
+#include <qpalette.h>
 
 class IconImageProvider : public QQuickImageProvider
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include <QQuickStyle>
 #include <QStyle>
 #include <QTimer>
+#include <qlogging.h>
 #include <qpalette.h>
 
 class IconImageProvider : public QQuickImageProvider
@@ -90,6 +91,13 @@ static void applyLightsOutPalette(QApplication &app, const QString &baseColor, b
     p.setColor(QPalette::HighlightedText, text);
     p.setColor(QPalette::PlaceholderText, subText);
     app.setPalette(p);
+}
+
+static bool lightsOutSupported()
+{
+    if (QQuickStyle::name().toLower().contains(QLatin1String("org.kde.desktop")))
+        return true;
+    return false;
 }
 
 int main(int argc, char *argv[])
@@ -144,7 +152,7 @@ int main(int argc, char *argv[])
 
     Launcher launcher;
     SettingsManager settingsManager;
-    applyLightsOutPalette(app, settingsManager.lightsOutColor(), settingsManager.lightsOut());
+    applyLightsOutPalette(app, settingsManager.lightsOutColor(), settingsManager.lightsOut() && lightsOutSupported());
     launcher.setGlobalEnvVars(settingsManager.globalEnvVars());
     launcher.setUmuPath(settingsManager.umuPath());
     launcher.setRetroarchPath(settingsManager.retroarchPath());
@@ -244,10 +252,10 @@ int main(int argc, char *argv[])
     RuntimeTypeModel runtimeTypeModel;
 
     QObject::connect(&settingsManager, &SettingsManager::lightsOutChanged, &app, [&]() {
-        applyLightsOutPalette(app, settingsManager.lightsOutColor(), settingsManager.lightsOut());
+        applyLightsOutPalette(app, settingsManager.lightsOutColor(), settingsManager.lightsOut() && lightsOutSupported());
     });
     QObject::connect(&settingsManager, &SettingsManager::lightsOutColorChanged, &app, [&]() {
-        applyLightsOutPalette(app, settingsManager.lightsOutColor(), settingsManager.lightsOut());
+        applyLightsOutPalette(app, settingsManager.lightsOutColor(), settingsManager.lightsOut() && lightsOutSupported());
     });
 
     QObject::connect(&settingsManager, &SettingsManager::defaultRuntimeChanged, [&]() {
@@ -438,6 +446,7 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty(QStringLiteral("singleInstance"), &singleInstance);
     engine.rootContext()->setContextProperty(QStringLiteral("gamepadHandler"), &gamepadHandler);
     engine.rootContext()->setContextProperty(QStringLiteral("openExePath"), openExePath);
+    engine.rootContext()->setContextProperty(QStringLiteral("lightsOutSupported"), lightsOutSupported());
     engine.rootContext()->setContextProperty(QStringLiteral("launchBigPicture"), parser.isSet(bigPictureOpt));
     engine.rootContext()->setContextProperty(QStringLiteral("isFlatpak"), isInsideFlatpak());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,9 +62,6 @@ public:
     }
 };
 
-// Lights Out is a custom dark overlay, not a real scheme switch. The QQC2
-// desktop style and icon SVG currentColor resolve from the actual QPalette, so
-// we swap in a dark palette here - otherwise icons/controls stay dark-on-dark.
 static void applyLightsOutPalette(QApplication &app, const QString &baseColor, bool on)
 {
     if (!on) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,10 +33,12 @@
 #include <QApplication>
 #include <QCommandLineParser>
 #include <QIcon>
+#include <QPalette>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QQuickImageProvider>
 #include <QQuickStyle>
+#include <QStyle>
 #include <QTimer>
 
 class IconImageProvider : public QQuickImageProvider
@@ -57,6 +59,37 @@ public:
         return pixmap;
     }
 };
+
+// Lights Out is a custom dark overlay, not a real scheme switch. The QQC2
+// desktop style and icon SVG currentColor resolve from the actual QPalette, so
+// we swap in a dark palette here - otherwise icons/controls stay dark-on-dark.
+static void applyLightsOutPalette(QApplication &app, const QString &baseColor, bool on)
+{
+    if (!on) {
+        app.setPalette(app.style()->standardPalette());
+        return;
+    }
+    QColor base(baseColor);
+    if (!base.isValid())
+        base = QColor(QStringLiteral("#2A2E32"));
+    const QColor text = QColor(Qt::white);
+    const QColor subText = QColor(255, 255, 255, 130);
+    const QColor mid = base.darker(120);
+    const QColor highlight = base.lighter(150);
+
+    QPalette p;
+    p.setColor(QPalette::Window, base);
+    p.setColor(QPalette::WindowText, text);
+    p.setColor(QPalette::Base, base);
+    p.setColor(QPalette::AlternateBase, mid);
+    p.setColor(QPalette::Text, text);
+    p.setColor(QPalette::Button, mid);
+    p.setColor(QPalette::ButtonText, text);
+    p.setColor(QPalette::Highlight, highlight);
+    p.setColor(QPalette::HighlightedText, text);
+    p.setColor(QPalette::PlaceholderText, subText);
+    app.setPalette(p);
+}
 
 int main(int argc, char *argv[])
 {
@@ -110,6 +143,7 @@ int main(int argc, char *argv[])
 
     Launcher launcher;
     SettingsManager settingsManager;
+    applyLightsOutPalette(app, settingsManager.lightsOutColor(), settingsManager.lightsOut());
     launcher.setGlobalEnvVars(settingsManager.globalEnvVars());
     launcher.setUmuPath(settingsManager.umuPath());
     launcher.setRetroarchPath(settingsManager.retroarchPath());
@@ -207,6 +241,13 @@ int main(int argc, char *argv[])
     GogModel gogModel;
 
     RuntimeTypeModel runtimeTypeModel;
+
+    QObject::connect(&settingsManager, &SettingsManager::lightsOutChanged, &app, [&]() {
+        applyLightsOutPalette(app, settingsManager.lightsOutColor(), settingsManager.lightsOut());
+    });
+    QObject::connect(&settingsManager, &SettingsManager::lightsOutColorChanged, &app, [&]() {
+        applyLightsOutPalette(app, settingsManager.lightsOutColor(), settingsManager.lightsOut());
+    });
 
     QObject::connect(&settingsManager, &SettingsManager::defaultRuntimeChanged, [&]() {
         launcher.setDefaultRuntimeType(settingsManager.defaultRuntimeType());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,8 +40,6 @@
 #include <QQuickStyle>
 #include <QStyle>
 #include <QTimer>
-#include <qlogging.h>
-#include <qpalette.h>
 
 class IconImageProvider : public QQuickImageProvider
 {


### PR DESCRIPTION
I am sorry I have to do this, but going forward, Lights Out will only be supported on Plasma (AppImage builds won't support it either). 
Lights out has been a pain in my butt since the first day. Never clicked. It either worked great on Plasma and broke on appimage/gnome or the other way around. Currently it's broken on plasma and I can't fix it no matter what I try.
On top of that, the implementation is very hacky, it's just tons of clutter in the qml files.
This is why I decided to make it work properly on Plasma and disable it everywhere else.